### PR TITLE
Improve character-limit validation, including on business form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ env-docker
 *.pyc
 /static/css/
 /static/build/
+/static/prod/*.js
+/static/prod/*.css
+/static/prod/*.jpg
+/static/prod/*.json
+/static/prod/*.png
 node_modules/
 *.DS_Store
 .cache

--- a/app.py
+++ b/app.py
@@ -217,8 +217,9 @@ def index_html_route():
 
 
 @app.route("/circle.html")
+@app.route("/circleform")
 def circle_html_route():
-    return redirect("/circleform", code=302)
+    return redirect("/circle", code=302)
 
 
 """
@@ -379,7 +380,7 @@ def member2_form():
     )
 
 
-@app.route("/circleform", methods=["GET", "POST"])
+@app.route("/circle", methods=["GET", "POST"])
 def circle_form():
     bundles = get_bundles("circle")
     template = "circle-form.html"

--- a/app.py
+++ b/app.py
@@ -219,7 +219,8 @@ def index_html_route():
 @app.route("/circle.html")
 @app.route("/circleform")
 def circle_html_route():
-    return redirect("/circle", code=302)
+    query_string = request.query_string.decode("utf-8")
+    return redirect("/circle?%s" % query_string, code=302)
 
 
 """

--- a/static/js/src/entry/business/BusinessForm.vue
+++ b/static/js/src/entry/business/BusinessForm.vue
@@ -33,7 +33,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.stripeEmail"
             label-text="email address"
-            maxlength="80"
             type="email"
             base-classes="form__text form__text--standard"
             name="stripeEmail"
@@ -49,7 +48,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.business_name"
             label-text="organization name"
-            maxlength="255"
             base-classes="form__text form__text--standard"
             name="business_name"
             store-module="businessForm"
@@ -61,7 +59,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.website"
             label-text="website"
-            maxlength="255"
             base-classes="form__text form__text--standard"
             name="website"
             store-module="businessForm"
@@ -76,7 +73,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.shipping_street"
             label-text="street address"
-            maxlength="255"
             base-classes="form__text form__text--standard"
             name="shipping_street"
             store-module="businessForm"
@@ -91,7 +87,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.shipping_city"
             label-text="city"
-            maxlength="40"
             base-classes="form__text form__text--standard"
             name="shipping_city"
             store-module="businessForm"
@@ -112,7 +107,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.shipping_postalcode"
             label-text="zip code"
-            maxlength="5"
             base-classes="form__text form__text--standard"
             name="shipping_postalcode"
             store-module="businessForm"
@@ -150,11 +144,13 @@
         <div class="col grid_separator">
           <text-input
             :required="false"
+            :show-error="showManualErrors || showNativeErrors"
+            :validation="validation.reason"
             label-text="encouraged to give by"
-            maxlength="255"
             base-classes="form__text form__text--standard"
             name="reason"
             store-module="businessForm"
+            @setValidationValue="setValidationValue"
           />
         </div>
       </div>
@@ -336,29 +332,29 @@ export default {
           manual: true,
           native: true,
           valid: false,
-          message: 'Enter a business name',
-          validator: this.isNotEmpty,
+          message: 'Enter a business name (255 characters or fewer)',
+          validator: this.isNotEmptyAndIsMaxLength(255),
         },
         website: {
           manual: true,
           native: true,
           valid: false,
           message: 'Enter a website, including https:// or http://',
-          validator: this.isURL,
+          validator: this.isValidWebsite,
         },
         shipping_street: {
           manual: true,
           native: true,
           valid: false,
-          message: 'Enter a street/mailing address',
-          validator: this.isNotEmpty,
+          message: 'Enter a street/mailing address (255 characters or fewer)',
+          validator: this.isNotEmptyAndIsMaxLength(255),
         },
         shipping_city: {
           manual: true,
           native: true,
           valid: false,
-          message: 'Enter a city',
-          validator: this.isNotEmpty,
+          message: 'Enter a city (40 characters or fewer)',
+          validator: this.isNotEmptyAndIsMaxLength(40),
         },
         shipping_postalcode: {
           manual: true,
@@ -381,6 +377,13 @@ export default {
           message: 'Enter contact last name',
           validator: this.isNotEmpty,
         },
+        reason: {
+          manual: true,
+          native: true,
+          valid: false,
+          message: 'Must be 255 characters or fewer',
+          validator: this.isMaxLength(255),
+        },
       },
       list_of_choices: US_STATES_SELECT_LIST,
     };
@@ -393,6 +396,10 @@ export default {
         { website: { url: true } },
       );
       return typeof isValid === 'undefined';
+    },
+
+    isValidWebsite(value) {
+      return this.isURL(value) && this.isMaxLength(255)(value);
     },
   },
 };

--- a/static/js/src/entry/business/BusinessForm.vue
+++ b/static/js/src/entry/business/BusinessForm.vue
@@ -1,5 +1,4 @@
 <template>
-
   <form
     ref="form"
     action="/business"
@@ -281,6 +280,8 @@
 </template>
 
 <script>
+import validate from 'validate.js';
+
 import Hidden from '../../elements/Hidden.vue';
 import Level from '../../elements/Level.vue';
 import LocalHidden from '../../elements/LocalHidden.vue';
@@ -296,7 +297,6 @@ import updateStoreValue from '../../elements/mixins/updateStoreValue';
 import formStarter from '../../mixins/form/starter';
 
 import { US_STATES_SELECT_LIST } from './formSelectListConstants';
-
 
 export default {
   name: 'BusinessForm',
@@ -384,6 +384,16 @@ export default {
       },
       list_of_choices: US_STATES_SELECT_LIST,
     };
+  },
+
+  methods: {
+    isURL(value) {
+      const isValid = validate(
+        { website: value.trim() },
+        { website: { url: true } },
+      );
+      return typeof isValid === 'undefined';
+    },
   },
 };
 </script>

--- a/static/js/src/entry/circle/CircleForm.vue
+++ b/static/js/src/entry/circle/CircleForm.vue
@@ -1,7 +1,7 @@
 <template>
   <form
     ref="form"
-    action="/circleform"
+    action="/circle"
     method="post"
     class="form circle-form"
     @submit="$event.preventDefault()"

--- a/static/js/src/entry/circle/CircleForm.vue
+++ b/static/js/src/entry/circle/CircleForm.vue
@@ -85,7 +85,6 @@
             :show-error="showManualErrors || showNativeErrors"
             :validation="validation.zipcode"
             label-text="zip code"
-            maxlength="5"
             base-classes="form__text form__text--standard"
             name="zipcode"
             store-module="circleForm"
@@ -280,7 +279,7 @@ export default {
           native: true,
           valid: false,
           message: 'Must be 255 characters or fewer',
-          validator: this.isValidReason,
+          validator: this.isMaxLength(255),
         },
       },
     };

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -303,7 +303,7 @@ export default {
           native: true,
           valid: false,
           message: 'Must be 255 characters or fewer',
-          validator: this.isValidReason,
+          validator: this.isMaxLength(255),
         },
       },
     };

--- a/static/js/src/mixins/form/starter.js
+++ b/static/js/src/mixins/form/starter.js
@@ -85,14 +85,6 @@ export default {
       return typeof isValid === 'undefined';
     },
 
-    isURL(value) {
-      const isValid = validate(
-        { website: value.trim() },
-        { website: { url: true } },
-      );
-      return typeof isValid === 'undefined';
-    },
-
     isNumeric(value) {
       const isValid = validate(
         { value: value.trim() },

--- a/static/js/src/mixins/form/starter.js
+++ b/static/js/src/mixins/form/starter.js
@@ -114,8 +114,17 @@ export default {
       return typeof isValid === 'undefined';
     },
 
-    isValidReason(value) {
-      return value.trim().length <= 255;
+    isMaxLength(maxLength) {
+      return value => (
+        value.trim().length <= maxLength
+      );
+    },
+
+    isNotEmptyAndIsMaxLength(maxLength) {
+      return value => (
+        this.isNotEmpty(value) &&
+        value.trim().length <= maxLength
+      );
     },
   },
 };


### PR DESCRIPTION
#### What's this PR do?
+ Makes client-side validation consistent with the restrictions enforced on the back end.
+ Cleans up our validator logic.
+ `.gitignore`s a bunch of compiled files that sometimes end up in version control because of weirdness between Heroku and our front-end build system.
+ Makes `/circleform` redirect to `/circle`.

#### Why are we doing this? How does it help us?
So donors get the error page when their form submission was successful. And the redirect is for consistency with the other URLs.

#### How should this be manually tested?
+ `make`
+ `make restart`
+ `yarn run dev`
+ Open up `forms.py` and find the business form.
+ Go to `/business` and ensure you can't exceed the character limits established in that file. Also ensure that, for all fields besides "encouraged by," empty values are not allowed. Also ensure the URL validation is still working for "website."
+ Make donations on both `/donate` and `/circleform`. Ensure the 255-character limit for "encouraged by" still works. And ensure going to the latter URL redirects you properly to `/circle`.

#### How should this change be communicated to end users?
I'll let Terry and others know about the move from `/circleform` to `/circle`.

#### Are there any smells or added technical debt to note?
NA.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/1419858300

#### Have you done the following, if applicable:
* [ ] Added automated tests? *(NA)*
* [ ] Tested manually on mobile? *(NA)*
* [ ] Checked for performance implications? *(NA)*
* [ ] Checked for security implications? *(NA)*
* [ ] Updated the documentation/wiki? *(NA)*