### PR TITLE
Build temporary Blast promo page

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -97,3 +97,21 @@ class BlastForm(FlaskForm):
     description = HiddenField(u"Description")
     pay_fees = BooleanField(u"Agree to pay fees")
     pay_fees_value = HiddenField(u"Pay Fees Value")
+
+
+class BlastPromoForm(FlaskForm):
+    first_name = StringField(
+        u"First name", [validators.required(message="Your first name is required.")]
+    )
+    last_name = StringField(
+        u"Last name", [validators.required(message="Your last name is required.")]
+    )
+    subscriber_email = EmailField(
+        "Subscriber Email address", [validators.DataRequired(), validators.Email()]
+    )
+    installment_period = HiddenField(u"Installment Period")
+    campaign_id = HiddenField("Campaign ID")
+    referral_id = HiddenField("Referral ID")
+    description = HiddenField(u"Description")
+    pay_fees = BooleanField(u"Agree to pay fees")
+    pay_fees_value = HiddenField(u"Pay Fees Value")

--- a/templates/blast-promo.html
+++ b/templates/blast-promo.html
@@ -40,7 +40,7 @@ The Blast | The Texas Tribune
             <header class="grid_separator--l">
                 <h1>Sign up for the best political newsletter in Texas.</h1>
             </header>
-            <div class="grid_row grid_wrap--l grid_wrap--reverse">
+            <div style="align-items: flex-start;" class="grid_row grid_wrap--l grid_wrap--reverse">
                 <div class="col col_7--xl">
                     <div class="grid_row grid_separator grid_wrap--m">
                         <div class="col_6">

--- a/templates/blast-promo.html
+++ b/templates/blast-promo.html
@@ -5,7 +5,7 @@ The Blast | The Texas Tribune
 {% block extra_script %}
 <script src="{{ url_for('static', filename='js/blast.js') }}"></script>
 <style>
-.subscription li label[for='amount-0']:before {
+    .subscription li label[for='amount-0']:before {
     content: 'Discounted rate';
 }
 
@@ -82,9 +82,7 @@ The Blast | The Texas Tribune
                             <label for="amount-0">Annual</label>
                         </li>
                     </ul>
-                    <h4 class="grid_separator--s">Would multiple people at your organization like to receive The Blast?
-                        Good news! We offer group rates.</h4>
-                    <p class="subtext">Email us at <a href="mailto:blast@texastribune.org">blast@texastribune.org</a>
+                    <p class="subtext">Got questions? Email us at <a href="mailto:blast@texastribune.org">blast@texastribune.org</a>
                         or call <a href="tel:+15127168695">512-716-8695</a> for more information.</p>
                 </div>
             </div>

--- a/templates/blast-promo.html
+++ b/templates/blast-promo.html
@@ -1,0 +1,116 @@
+{% extends "layout.html" %}
+{% block title %}
+The Blast | The Texas Tribune
+{% endblock %}
+{% block extra_script %}
+<script src="{{ url_for('static', filename='js/blast.js') }}"></script>
+<style>
+.subscription li label[for='amount-0']:before {
+    content: 'Discounted rate';
+}
+
+.subscription li label[for='amount-0']:after {
+    content: '$200'
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<header class="blast_header">
+    <div class="grid_container grid_row grid_padded blast_main grid_wrap--m">
+        <figure class="blast_logo col col_6--m col_5--l">
+            <a href="https://www.texastribune.org/theblast/" class="unlink"><img src="{{ url_for('static', filename='img/TT-TheBlast-logo_PSvitek.png') }}"
+                    alt="The Blast logo, a product of The Texas Tribune"></a>
+            <!-- <a href="https://www.texastribune.org/" class="unlink"><img src="{{ url_for('static', filename='img/TT-aprojectby-horizontal-white.svg') }}" alt="A product of The Texas Tribune" class="blast_logo--sub"></a> -->
+        </figure>
+        <div class="col col_2--m col_4--l">&nbsp;</div>
+        <div class="col ttproduct">
+            <figure>
+                <img src="{{ url_for('static', filename='img/TT-aprojectby.svg')}}" alt="A project by The Texas Tribune">
+            </figure>
+        </div>
+    </div>
+</header>
+<div id="blast" class="grid_container blast_main">
+    <form action="/submit-blast-promo" method="post" class="blastform grid_separator--l">
+        <input name="campaign_id" id="campaign_id" value="{{ campaign_id }}" type="hidden">
+        <input name="referral_id" id="referral_id" value="{{ referral_id }}" type="hidden">
+        <div class="form-outer-section outer-section narrow">
+
+            <header class="grid_separator--l">
+                <h1>Sign up for the best political newsletter in Texas.</h1>
+            </header>
+            <div class="grid_row grid_wrap--l grid_wrap--reverse">
+                <div class="col col_7--xl">
+                    <div class="grid_row grid_separator grid_wrap--m">
+                        <div class="col_6">
+                            {{ form.first_name.label }}<br>
+                            {{ form.first_name(maxlength=50) }}
+                        </div>
+                        <div class="col_6">
+                            {{ form.last_name.label }}<br>
+                            {{ form.last_name(maxlength=50) }}
+                        </div>
+                    </div>
+                    <div class="grid_row">
+                        <div class="col">
+                            {{ form.subscriber_email.label }}
+                            {{ form.subscriber_email(maxlength=70) }}
+                            <p class="form-subtext">&raquo; You will be prompted for the billing email address at
+                                checkout.</p>
+                        </div>
+                    </div>
+                    <div class="grid_row">
+                        <div class="col col_9--l">
+                            {{ form.pay_fees.label }}
+                            {{ form.pay_fees(checked=False) }}
+                            <p id="pay-fee-amount" class="label-info"><span></span></p>
+                            <p id="pay-fee-info">Paying these fees directs more money in support of the Tribune’s
+                                mission.</p>
+                        </div>
+                    </div>
+                    {{ form.pay_fees_value(value="False") }}
+                    {{ form.installment_period(value=installment_period) }}
+                    <div class="form-section form-error">
+                        <p class="error-form-message"></p>
+                    </div>
+                </div>
+                <div class="col col_5--xl form__box grid_separator">
+                    <ul class="subscription grid_row">
+                        <li class="col grid_separator">
+                            <input checked id="amount-0" name="amount" type="radio" value="200">
+                            <label for="amount-0">Annual</label>
+                        </li>
+                    </ul>
+                    <h4 class="grid_separator--s">Would multiple people at your organization like to receive The Blast?
+                        Good news! We offer group rates.</h4>
+                    <p class="subtext">Email us at <a href="mailto:blast@texastribune.org">blast@texastribune.org</a>
+                        or call <a href="tel:+15127168695">512-716-8695</a> for more information.</p>
+                </div>
+            </div>
+            {{ form.description(value='Blast Subscription') }}
+            <script src="https://checkout.stripe.com/checkout.js"></script>
+            <button id="customButton" class="button button-flat">Submit</button>
+        </div>
+    </form>
+
+
+    {% include 'includes/blast_stripe_checkout_js.html' %}
+</div>
+<script>
+    window.onload = function () {
+        payFeeAmount();
+        listen_for_fee_check();
+    };
+
+    $('input[name="amount"]').change(function () {
+        payFeeAmount();
+        $('input[name="amount"]').each(function () {
+            $(this).attr("checked", false);
+        });
+        $(this).attr("checked", "checked");
+        $(this).prop("checked", true);
+    });
+
+</script>
+{% endblock %}

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,94 +1,101 @@
 <footer>
-  <div id="site_footer" class="site_footer">
-    <div class="grid_container grid_row">
-      <div class="col">
-        <figure class="site_footer--logo">
-          <img src="../static/img/TxTrib-bug-logo.svg" alt="">
-        </figure>
-        <ul>
-          <div class="border--yellow_notch"></div>
-          <li>
-            <a href="https://www.texastribune.org/contact/" title="Contact Us">Contact Us</a>
-          </li>
-          <li>
-            <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise">Advertise</a>
-          </li>
-          <li><a href="https://texastribune.org">&copy; 2018 The Texas Tribune</a></li>
-        </ul>
-      </div>
-      <div id="footer-sections" class="col hide_until--s">
-        <h5 class="site_footer--header">Topics</h5>
-        <ul>
-          {% include "./includes/section_list_items.html" %}
-        </ul>
-      </div>
-      <div class="col">
-        <h5 class="site_footer--header">Info</h5>
-        <ul>
-          <li>
-            <a href="https://www.texastribune.org/about/" title="About Us">About Us</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/staff/">Our Staff</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?">Who Funds Us?</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines">Republishing Guidelines</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics">Code of Ethics</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service">Terms of Service</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy">Privacy Policy</a>
-          </li>
+    <div id="site_footer" class="site_footer">
+        <div class="grid_container grid_row">
+            <div class="col">
+                <figure class="site_footer--logo">
+                    <img src="../static/img/TxTrib-bug-logo.svg" alt="">
+                </figure>
+                <ul>
+                    <div class="border--yellow_notch"></div>
+                    <li>
+                        <a href="https://www.texastribune.org/contact/" title="Contact Us">Contact Us</a>
+                    </li>
+                    <li>
+                        <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise">Advertise</a>
+                    </li>
+                    <li><a href="https://texastribune.org">&copy; 2019 The Texas Tribune</a></li>
+                </ul>
+            </div>
+            <div id="footer-sections" class="col hide_until--s">
+                <h5 class="site_footer--header">Topics</h5>
+                <ul>
+                    {% include "./includes/section_list_items.html" %}
+                </ul>
+            </div>
+            <div class="col">
+                <h5 class="site_footer--header">Info</h5>
+                <ul>
+                    <li>
+                        <a href="https://www.texastribune.org/about/" title="About Us">About Us</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/staff/">Our Staff</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?">Who
+                            Funds Us?</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines">Republishing
+                            Guidelines</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics">Code of Ethics</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service">Terms
+                            of Service</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy">Privacy
+                            Policy</a>
+                    </li>
 
-          <li>
-            <a href="https://www.texastribune.org/about/tips/" title="Send a Tip">Send us a confidential tip</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/corrections/" title="Corrections">Corrections</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/feeds/" title="Feeds">Feeds</a>
-          </li>
-          <li>
-            <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters">Newsletters</a>
-          </li>
-        </ul>
-      </div>
-      <div class="col">
-        <h5 class="site_footer--header">Social Media</h5>
-        <ul>
-          <li>
-            <a href="http://facebook.com/texastribune" title="Facebook" class="external"><i class="fa fa-facebook"></i>Facebook</a>
-          </li>
-          <li>
-            <a href="http://twitter.com/texastribune" title="Twitter" class="external"><i class="fa fa-twitter"></i>Twitter</a>
-          </li>
-          <li>
-            <a href="http://youtube.com/user/thetexastribune" title="YouTube" class="external"><i class="fa fa-youtube"></i>YouTube</a>
-          </li>
-          <li>
-            <a href="http://instagram.com/texas_tribune" title="Instagram" class="external"><i class="fa fa-instagram"></i>Instagram</a>
-          </li>
-          <li>
-            <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external"><i class="fa fa-linkedin"></i>LinkedIn</a>
-          </li>
-          <li>
-            <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external"><i class="fa fa-reddit"></i>Reddit</a>
-          </li>
-          <div class="border--yellow_notch"></div>
-          <li>
-            <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external"><i class="fa fa-facebook"></i>Join our Facebook Group, This Is Your Texas.</a>
-          </li>
-        </ul>
-      </div>
+                    <li>
+                        <a href="https://www.texastribune.org/about/tips/" title="Send a Tip">Send us a confidential
+                            tip</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/corrections/" title="Corrections">Corrections</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/feeds/" title="Feeds">Feeds</a>
+                    </li>
+                    <li>
+                        <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters">Newsletters</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col">
+                <h5 class="site_footer--header">Social Media</h5>
+                <ul>
+                    <li>
+                        <a href="http://facebook.com/texastribune" title="Facebook" class="external"><i class="fa fa-facebook"></i>Facebook</a>
+                    </li>
+                    <li>
+                        <a href="http://twitter.com/texastribune" title="Twitter" class="external"><i class="fa fa-twitter"></i>Twitter</a>
+                    </li>
+                    <li>
+                        <a href="http://youtube.com/user/thetexastribune" title="YouTube" class="external"><i class="fa fa-youtube"></i>YouTube</a>
+                    </li>
+                    <li>
+                        <a href="http://instagram.com/texas_tribune" title="Instagram" class="external"><i class="fa fa-instagram"></i>Instagram</a>
+                    </li>
+                    <li>
+                        <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external"><i
+                                class="fa fa-linkedin"></i>LinkedIn</a>
+                    </li>
+                    <li>
+                        <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external"><i class="fa fa-reddit"></i>Reddit</a>
+                    </li>
+                    <div class="border--yellow_notch"></div>
+                    <li>
+                        <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external"><i
+                                class="fa fa-facebook"></i>Join our Facebook Group, This Is Your Texas.</a>
+                    </li>
+                </ul>
+            </div>
 
+        </div>
     </div>
-  </div>
 </footer>


### PR DESCRIPTION
#### What's this PR do?
What the title says.

#### Why are we doing this? How does it help us?
Membership request.

#### How should this be manually tested?
+ `make restart` (or just visit the Heroku test link)
+ Go to `/blast-promo` and confirm the only price option is $200 annually
+ Confirm you can fill out and submit the form successfully (@x110dc how do you verify a test subscription was successful?)

#### How should this change be communicated to end users?
Membership will handle that.

#### Are there any smells or added technical debt to note?
Not really as this is temporary.

#### What are the relevant tickets?
Off-sprint.

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [x] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked for security implications?
* [ ] Updated the documentation/wiki?

#### TODOs / next steps:
Redirect `/blast-promo` to `/blastform` when this promo is over.