### PR TITLE
Changes to Slack notifications and a few odds and ends

### DIFF
--- a/app.py
+++ b/app.py
@@ -745,19 +745,18 @@ def add_recurring_donation(contact=None, form=None, customer=None):
 
     installments = form["installments"]
 
-    open_ended_status = form["openended_status"]
     installment_period = form["installment_period"]
-    rdo.open_ended_status = open_ended_status
     rdo.installments = installments
     rdo.installment_period = installment_period
 
-    if (
-        open_ended_status is None
-        and (installments == 3 or installments == 36)
-        and (installment_period == "yearly" or installment_period == "monthly")
+    if (installments == 3 or installments == 36) and (
+        installment_period == "yearly" or installment_period == "monthly"
     ):
         rdo.type = "Giving Circle"
         rdo.description = "Texas Tribune Circle Membership"
+        rdo.open_ended_status = "None"
+    else:
+        rdo.open_ended_status = "Open"
 
     apply_card_details(rdo=rdo, customer=customer)
     rdo.save()
@@ -809,7 +808,7 @@ def add_business_rdo(account=None, form=None, customer=None):
     rdo.lead_source = "Stripe"
     rdo.amount = form.get("amount", 0)
     rdo.installments = form["installments"]
-    rdo.open_ended_status = form["openended_status"]
+    rdo.open_ended_status = "Open"
     rdo.installment_period = form["installment_period"]
 
     apply_card_details(rdo=rdo, customer=customer)

--- a/app.py
+++ b/app.py
@@ -590,7 +590,7 @@ def authorization_notification(payload):
     opportunity = Opportunity(contact=contact, stage_name="Closed Won")
     opportunity.amount = amount
     opportunity.description = description
-    opportunity.lead_source = "Amazon Pay"
+    opportunity.lead_source = "Amazon Alexa"
     opportunity.amazon_order_id = amzn_id
     opportunity.campaign_id = AMAZON_CAMPAIGN_ID
     opportunity.name = (

--- a/app.py
+++ b/app.py
@@ -846,7 +846,9 @@ def add_business_membership(form=None, customer=None):
     contact = Contact.get_or_create(
         email=email, first_name=first_name, last_name=last_name
     )
-
+    if contact.work_email is None:
+        contact.work_email = email
+        contact.save()
     logging.info(contact)
 
     if contact.first_name == "Subscriber" and contact.last_name == "Subscriber":

--- a/app.py
+++ b/app.py
@@ -668,18 +668,17 @@ def stripehook():
     payload = request.data.decode("utf-8")
     signature = request.headers.get("Stripe-Signature", None)
 
-    print(payload)
-    print(signature)
+    app.logger.info(payload)
 
     try:
         event = stripe.Webhook.construct_event(
             payload, signature, STRIPE_WEBHOOK_SECRET
         )
     except ValueError:
-        print("Error while decoding event!")
+        app.logger.warning("Error while decoding event!")
         return "Bad payload", 400
     except stripe.error.SignatureVerificationError:
-        print("Invalid signature!")
+        app.logger.warning("Invalid signature!")
         return "Bad signature", 400
 
     app.logger.info(f"Received event: id={event.id}, type={event.type}")

--- a/app.py
+++ b/app.py
@@ -882,7 +882,7 @@ def add_business_membership(form=None, customer=None):
         )
         logging.info(opportunity)
         charge(opportunity)
-        notify_slack(account=account, opportunity=opportunity)
+        notify_slack(account=account, contact=contact, opportunity=opportunity)
     else:
         logging.info("----Creating recurring business membership...")
         rdo = add_business_rdo(account=account, form=form, customer=customer)
@@ -896,7 +896,7 @@ def add_business_membership(form=None, customer=None):
             if opportunity.expected_giving_date == today
         ][0]
         charge(opp)
-        notify_slack(account=account, rdo=rdo)
+        notify_slack(account=account, contact=contact, rdo=rdo)
 
     logging.info("----Getting affiliation...")
 

--- a/charges.py
+++ b/charges.py
@@ -68,15 +68,14 @@ def charge(opportunity):
             user = User.get(CIRCLE_FAILURE_RECIPIENT)
             subject = "Credit card charge failed for Circle member"
             task = Task(owner_id=user.id, what_id=opportunity.id, subject=subject)
-            print("sending slack message")
-            send_slack_message(
-                channel="#circle",
-                text=f"Circle charge failed for {opportunity.name} [{opportunity.closed_lost_reason}]",
-                icon_emoji=":x:",
-            )
-
             task.save()
-
+            send_slack_message(
+                {
+                    "channel": "#circle-failures",
+                    "text": f"Circle charge failed for {opportunity.name} [{opportunity.closed_lost_reason}]",
+                    "icon_emoji": ":x:",
+                }
+            )
         return
 
     except stripe.error.InvalidRequestError as e:

--- a/charges.py
+++ b/charges.py
@@ -3,6 +3,7 @@ import logging
 from decimal import Decimal
 from config import STRIPE_KEYS, CIRCLE_FAILURE_RECIPIENT
 from npsp import User, Task
+from util import send_slack_message
 
 import stripe
 
@@ -67,6 +68,13 @@ def charge(opportunity):
             user = User.get(CIRCLE_FAILURE_RECIPIENT)
             subject = "Credit card charge failed for Circle member"
             task = Task(owner_id=user.id, what_id=opportunity.id, subject=subject)
+            print("sending slack message")
+            send_slack_message(
+                channel="#circle",
+                text=f"Circle charge failed for {opportunity.name} [{opportunity.closed_lost_reason}]",
+                icon_emoji=":x:",
+            )
+
             task.save()
 
         return

--- a/npsp.py
+++ b/npsp.py
@@ -403,7 +403,6 @@ class Opportunity(SalesforceObject):
         if not opportunities:
             raise SalesforceException("at least one Opportunity must be specified")
         sf = SalesforceConnection() if sf_connection is None else sf_connection
-        print(card_details)
         return sf.updates(opportunities, card_details)
 
     def __str__(self):

--- a/npsp.py
+++ b/npsp.py
@@ -754,6 +754,7 @@ class Contact(SalesforceObject):
         self.lead_source = "Stripe"
         self.mailing_postal_code = None
         self.duplicate_found = False
+        self.work_email = None
 
     @property
     def name(self):
@@ -780,6 +781,7 @@ class Contact(SalesforceObject):
             "LastName": self.last_name,
             "LeadSource": self.lead_source,
             "MailingPostalCode": self.mailing_postal_code,
+            "npe01__WorkEmail__c": self.work_email,
         }
 
     @classmethod
@@ -808,7 +810,7 @@ class Contact(SalesforceObject):
             raise SalesforceException("id and email can't both be specified")
         if id:
             query = f"""
-                    SELECT Id, AccountId, FirstName, LastName, LeadSource, Stripe_Customer_ID__c, MailingPostalCode, Email
+                    SELECT Id, AccountId, FirstName, LastName, LeadSource, Stripe_Customer_ID__c, MailingPostalCode, Email, npe01__WorkEmail__c
                     FROM Contact
                     WHERE id = '{id}'
                     """
@@ -824,11 +826,12 @@ class Contact(SalesforceObject):
             contact.email = response["Email"]
             contact.lead_source = response["LeadSource"]
             contact.mailing_postal_code = response["MailingPostalCode"]
+            contact.work_email = response["npe01__WorkEmail__c"]
             contact.created = False
             return contact
 
         query = f"""
-                SELECT Id, AccountId, FirstName, LastName, LeadSource, MailingPostalCode, All_In_One_EMail__c, Email
+                SELECT Id, AccountId, FirstName, LastName, LeadSource, MailingPostalCode, All_In_One_EMail__c, Email, npe01__WorkEmail__c
                 FROM Contact
                 WHERE All_In_One_EMail__c
                 LIKE '%{email}%'
@@ -850,6 +853,7 @@ class Contact(SalesforceObject):
         contact.last_name = response["LastName"]
         contact.email = response["Email"]
         contact.lead_source = response["LeadSource"]
+        contact.work_email = response["npe01__WorkEmail__c"]
         contact.mailing_postal_code = response["MailingPostalCode"]
         contact.created = False
 

--- a/tests.py
+++ b/tests.py
@@ -382,6 +382,7 @@ def test__format_contact():
     contact.first_name = "D"
     contact.last_name = "C"
     contact.lead_source = "Stripe"
+    contact.work_email = "dcraigmile+test6@texastribune.org"
 
     response = contact._format()
 
@@ -391,6 +392,7 @@ def test__format_contact():
         "LastName": "C",
         "LeadSource": "Stripe",
         "MailingPostalCode": None,
+        "npe01__WorkEmail__c": "dcraigmile+test6@texastribune.org",
     }
 
     assert response == expected_response

--- a/util.py
+++ b/util.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import logging
 import smtplib
 from collections import defaultdict
@@ -116,6 +117,9 @@ def construct_slack_attachment(
     donation_type=None,
     reason=None,
 ):
+
+    grav_hash = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+
     attachment = {
         "fallback": "Donation",
         "color": "good",
@@ -123,7 +127,7 @@ def construct_slack_attachment(
         # # "text": "text",
         "author_name": donor,
         # author_link
-        # author_icon
+        "author_icon": f"https://www.gravatar.com/avatar/{grav_hash}?s=16&r=g&default=robohash",
         "title": email,
         # "title_link":
         # "text": reason,

--- a/util.py
+++ b/util.py
@@ -73,34 +73,36 @@ def notify_slack(contact=None, opportunity=None, rdo=None, account=None):
     )
     message = {
         "channel": SLACK_CHANNEL,
-        "attachments": [attachment],
+        "attachments": json.dumps([attachment]),
         "icon_emoji": ":moneybag:",
     }
     send_slack_message(message=message)
-    return
 
-    text = construct_slack_message(
-        contact=contact, opportunity=opportunity, rdo=rdo, account=account
-    )
-    message = {
-        "text": text,
-        "channel": SLACK_CHANNEL,
-        "username": opportunity.lead_source,
-        "icon_emoji": ":moneybag:",
-    }
+    # text = construct_slack_message(
+    #     contact=contact, opportunity=opportunity, rdo=rdo, account=account
+    # )
+    # message = {
+    #     "text": text,
+    #     "channel": SLACK_CHANNEL,
+    #     "username": opportunity.lead_source,
+    #     "icon_emoji": ":moneybag:",
+    # }
 
-    send_slack_message(message)
+    # send_slack_message(message)
 
 
-def send_slack_message(message=None):
+def send_slack_message(message=None, username="moneybot"):
 
     if not ENABLE_SLACK or not message:
         return
-
     message["token"] = SLACK_API_KEY
+    message["username"] = username
     url = "https://slack.com/api/chat.postMessage"
     try:
-        requests.get(url, params=message)
+        response = requests.post(url, params=message)
+        slack_response = json.loads(response.text)
+        if not slack_response["ok"]:
+            raise Exception(slack_response["error"])
     except Exception as e:
         logging.error(f"Failed to send Slack notification: {e}")
 
@@ -115,95 +117,31 @@ def construct_slack_attachment(
     reason=None,
 ):
     attachment = {
-        # "pretext"
         "fallback": "Donation",
         "color": "good",
-        # "text": "text",
+        # "pretext": "optional and appears above attachment"
+        # # "text": "text",
         "author_name": donor,
         # author_link
         # author_icon
         "title": email,
+        # "title_link":
+        # "text": reason,
         # title_link
         "fields": [
-            {"title": "Source", "value": source, "short": False},
+            {"title": "Source", "value": source, "short": True},
             {"title": "Amount", "value": f"${amount}", "short": True},
-            {"title": "Period", "value": period, "short": False},
-            {"title": "Type", "value": donation_type, "short": False},
-            {"title": "Reason", "value": reason, "short": False},
+            {"title": "Period", "value": period, "short": True},
+            {"title": "Type", "value": donation_type, "short": True},
         ],
+        # "image_url":
+        # "thumb_url":
+        # "footer":
+        # "footer_icon":
+        # "ts":
     }
 
-    if reason:
-        attachment["fields"].append(
-            {"title": "Reason", "value": reason, "short": False}
-        )
-        pprint(attachment, indent=2)
     return attachment
-
-
-def send_slack_attachment(
-    channel=SLACK_CHANNEL, attachment=None, username="moneybot", icon_emoji=":moneybag:"
-):
-
-    if not ENABLE_SLACK:
-        return
-    payload = {
-        "channel": channel,
-        "attachments": attachment,
-        "username": "Foo Bar",
-        "icon_emoji": ":moneybag:",
-    }
-    pprint(payload)
-    url = "https://slack.com/api/chat.postMessage"
-    headers = {
-        "Authorization": f"Bearer {SLACK_API_KEY}",
-        "Content-type": "application/json; charset=utf-8",
-    }
-    try:
-        response = requests.post(url, headers=headers, json=payload)
-    except Exception as e:
-        logging.error(f"Failed to send Slack notification: {e}")
-    pprint(response.text, indent=2)
-
-    # {
-    # 	"icon_emoji": ":moneybag:",
-    # 	"attachments": [
-    #         {
-    #             "fallback": "Required plain-text summary of the attachment.",
-    #             "color": "#2eb886",
-    #             "pretext": "Optional text that appears above the attachment block",
-    #             "author_name": "Bobby Tables",
-    #             "author_link": "http://flickr.com/bobby/",
-    #             "author_icon": "http://flickr.com/icons/bobby.jpg",
-    #             "title": "Your Name Here",
-    #             "title_link": "https://api.slack.com/",
-    #             "text": "Optional text that appears within the attachment",
-    #              "fields": [
-    #                 {"title": "Source", "value": "Amazon Alexa", "short": true},
-    #                 {"title": "Amount", "value": "$5", "short": true},
-    #                 {"title": "Period", "value": "yearly", "short": true},
-    #                 {"title": "Type", "value": "Circle", "short": true}
-    #             ],
-    #             "image_url": "http://my-website.com/path/to/image.jpg",
-    #             "thumb_url": "http://example.com/path/to/thumb.png",
-    #             "footer": "Slack API",
-    #             "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
-    #             "ts": 123456789
-    #         }
-    #     ]
-    # }
-    # attachment = [
-    #     {
-    #         "fallback": "Deployment status.",
-    #         "color": "good",
-    #         "mrkdwn_in": ["text"],
-    #         "title": "instance_name",
-    #         "fields": [
-    #             {"value": "status", "short": False},
-    #             {"value": "Command ID: foo", "short": False},
-    #         ],
-    #     }
-    # ]
 
 
 def send_multiple_account_warning(contact):

--- a/util.py
+++ b/util.py
@@ -18,7 +18,7 @@ from config import (
 
 import requests
 
-from npsp import SalesforceConnection, SalesforceException
+from npsp import SalesforceConnection, SalesforceException, DEFAULT_RDO_TYPE
 
 
 def construct_slack_message(contact=None, opportunity=None, rdo=None, account=None):
@@ -53,8 +53,10 @@ def notify_slack(contact=None, opportunity=None, rdo=None, account=None):
     name = account.name if account else contact.name
     source = rdo.lead_source if rdo else opportunity.lead_source
     amount = rdo.amount if rdo else opportunity.amount
-    period = rdo.installment_period if rdo else "Single"
-    donation_type = rdo.record_type_name if rdo else opportunity.record_type_name
+    period = rdo.installment_period if rdo else "single"
+    donation_type = rdo.type if rdo else opportunity.record_type_name
+    if donation_type == "Recurring Donation":
+        donation_type = DEFAULT_RDO_TYPE
 
     if rdo and rdo.encouraged_by:
         reason = rdo.encouraged_by
@@ -144,6 +146,8 @@ def construct_slack_attachment(
         # "footer_icon":
         # "ts":
     }
+    if reason:
+        attachment["text"] = reason
 
     return attachment
 

--- a/util.py
+++ b/util.py
@@ -74,42 +74,34 @@ def send_slack_message(
         logging.error(f"Failed to send Slack notification: {e}")
 
 
-def send_slack_attachment(
-    channel=SLACK_CHANNEL, attachment=None, username="moneybot", icon_emoji=":moneybag:"
+def make_slack_attachment(
+    email=None, donor=None, source=None, amount=None, period=None
 ):
+
     attachment = [
         {
-            "as_user": False,
-            "icon_emoji": ":moneybag:",
-            "fallback": "This is the fallback",
+            # "pretext"
+            "fallback": "Donation",
             "color": "good",
-            "text": "text",
-            #            "pretext": "foo@bar.com",
+            # "text": "text",
+            "author_name": donor,
+            # author_link
+            # author_icon
+            "title": email,
+            # title_link
             "fields": [
-                {"title": "Source", "value": "Amazon Alexa", "short": True},
-                {"title": "Amount", "value": "$5", "short": True},
-                {"title": "Name", "value": "Foo Bar", "short": False},
-                {"title": "Period", "value": "yearly", "short": True},
-                {"title": "Type", "value": "Circle", "short": True},
+                {"title": "Source", "value": source, "short": False},
+                {"title": "Amount", "value": f"${amount}", "short": True},
+                {"title": "Period", "value": period, "short": False},
+                {"title": "Type", "value": type, "short": False},
             ],
         }
     ]
-    # attachment = [
-    #     {
-    #         "fallback": "Deployment status.",
-    #         "color": "good",
-    #         "mrkdwn_in": ["text"],
-    #         "title": "instance_name",
-    #         "fields": [
-    #             {"value": "status", "short": False},
-    #             {"value": "Command ID: foo", "short": False},
-    #         ],
-    #     }
-    # ]
 
-    from pprint import pprint
 
-    pprint(attachment)
+def send_slack_attachment(
+    channel=SLACK_CHANNEL, attachment=None, username="moneybot", icon_emoji=":moneybag:"
+):
 
     if not ENABLE_SLACK:
         return
@@ -130,6 +122,46 @@ def send_slack_attachment(
     except Exception as e:
         logging.error(f"Failed to send Slack notification: {e}")
     pprint(response.text, indent=2)
+
+    # {
+    # 	"icon_emoji": ":moneybag:",
+    # 	"attachments": [
+    #         {
+    #             "fallback": "Required plain-text summary of the attachment.",
+    #             "color": "#2eb886",
+    #             "pretext": "Optional text that appears above the attachment block",
+    #             "author_name": "Bobby Tables",
+    #             "author_link": "http://flickr.com/bobby/",
+    #             "author_icon": "http://flickr.com/icons/bobby.jpg",
+    #             "title": "Your Name Here",
+    #             "title_link": "https://api.slack.com/",
+    #             "text": "Optional text that appears within the attachment",
+    #              "fields": [
+    #                 {"title": "Source", "value": "Amazon Alexa", "short": true},
+    #                 {"title": "Amount", "value": "$5", "short": true},
+    #                 {"title": "Period", "value": "yearly", "short": true},
+    #                 {"title": "Type", "value": "Circle", "short": true}
+    #             ],
+    #             "image_url": "http://my-website.com/path/to/image.jpg",
+    #             "thumb_url": "http://example.com/path/to/thumb.png",
+    #             "footer": "Slack API",
+    #             "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+    #             "ts": 123456789
+    #         }
+    #     ]
+    # }
+    # attachment = [
+    #     {
+    #         "fallback": "Deployment status.",
+    #         "color": "good",
+    #         "mrkdwn_in": ["text"],
+    #         "title": "instance_name",
+    #         "fields": [
+    #             {"value": "status", "short": False},
+    #             {"value": "Command ID: foo", "short": False},
+    #         ],
+    #     }
+    # ]
 
 
 def send_multiple_account_warning(contact):


### PR DESCRIPTION
#### What's this PR do?

- converts some `print` statements to `logging` 
- determines `open_ended_status` from other fields
- populates "Corporate Email" field for business memberships
- sends a notification to Slack when Circle member charges fail
- changes regular Slack notifications from a single line to an attachment

#### Why are we doing this? How does it help us?

- They want to know right away when Circle charges fail so they can follow up. 
- The `open_ended_status` field has been confusing. And it can be determined completely by the values in the `installment` and `installment_period` fields. This makes it so that the frontend no longer needs to send that field through to the backend.
- Slack notifications were getting increasingly complicated as the different types of donations were growing. Converting it to attachment style means that if we want to add some new bit of data in the future we can just add another field. 
- They want both the corporate and regular email fields to be populated for business memberships.

#### How should this be manually tested?

- Make a test circle donation with the card number `4000000000000341`. Make sure it shows up in the `#circle-failures` channel.
- Make one time, monthly and yearly regular donations. Confirm that it shows up properly in `#stripe`
- Make monthly and yearly Circle donations. Confirm the same.
- Add a business membership. Confirm the same.

#### How should this change be communicated to end users?

Let Catherine, Terry, Anna and Sarah know. 

#### Are there any smells or added technical debt to note?

I left some of the old-style notification code in there in case we want to use it again.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/1458052819

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *(will after merge)*