### PR TITLE
CSS reorg round 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,9 +33,6 @@ indent_size = 2
 [*.sass]
 indent_size = 2
 
-[*.html]
-indent_size = 2
-
 # Makefiles always use tabs for indentation
 [Makefile]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,9 @@ indent_size = 2
 [*.sass]
 indent_size = 2
 
+[*.html]
+indent_size = 2
+
 # Makefiles always use tabs for indentation
 [Makefile]
 indent_style = tab

--- a/static/js/src/entry/business/index.js
+++ b/static/js/src/entry/business/index.js
@@ -7,7 +7,7 @@ import { createRouter, bindRouterEvents } from './router';
 import cssClasses from '../../mixins/global/cssClasses';
 import gtm from '../../mixins/global/gtm';
 
-import '../../../../sass/business.scss';
+import '../../../../sass/business-update.scss';
 
 require('es6-promise').polyfill();
 

--- a/static/js/src/entry/circle/index.js
+++ b/static/js/src/entry/circle/index.js
@@ -7,7 +7,7 @@ import { createRouter, bindRouterEvents } from './router';
 import cssClasses from '../../mixins/global/cssClasses';
 import gtm from '../../mixins/global/gtm';
 
-import '../../../../sass/circle.scss';
+import '../../../../sass/circle-update.scss';
 
 require('es6-promise').polyfill();
 

--- a/static/sass/1-settings/_all.scss
+++ b/static/sass/1-settings/_all.scss
@@ -1,0 +1,5 @@
+// SETTINGS - SASS variables used throughout app
+// Note: Should not output CSS
+@import 'breakpoints';
+@import 'colors';
+@import 'fonts';

--- a/static/sass/1-settings/_breakpoints.scss
+++ b/static/sass/1-settings/_breakpoints.scss
@@ -1,0 +1,33 @@
+// sass-mq settings
+$mq-responsive: true;
+
+$bp-xs: 320px;
+$bp-s: 520px;
+$bp-m: 650px;
+$bp-l: 845px;
+$bp-xl: 1080px;
+$bp-xxl: 1300px;
+
+$bp-default: 960px;
+
+$mq-breakpoints: (
+  bp-xs: $bp-xs,
+  bp-s: $bp-s,
+  bp-m: $bp-m,
+  bp-l: $bp-l,
+  bp-xl: $bp-xl,
+  bp-xxl: $bp-xxl,
+  bp-default: $bp-default
+);
+
+// Sizes in comparison to 16px root
+$size-xxxl: 3rem;
+$size-giant: 2.5rem;
+$size-xxl: 2rem;
+$size-xl: 1.75rem;
+$size-l: 1.5rem;
+$size-m: 1.2rem;
+$size-b: 1.1rem;
+$size-s: .92rem;
+$size-xs: .85rem;
+$size-xxs: .7rem;

--- a/static/sass/1-settings/_colors.scss
+++ b/static/sass/1-settings/_colors.scss
@@ -1,0 +1,26 @@
+// Accent colors
+$color-yellow-tribune: #ffc200;
+$color-blue-light: #a1d2df;
+$color-blue-dark: #223136;
+$color-teal-gray: #539bae;
+$color-red: #ff6047;
+$color-sand: #f2ede2;
+
+// Grayscale
+$color-white-pure: #fff;
+$color-white-off: #f3f3f3;
+$color-gray-light: #d0d0d0;
+$color-gray-medium: #797979;
+$color-gray-dark: #4a4a4a;
+$color-black-off: #222;
+$color-black-pure: #000;
+
+// Social colors
+$color-facebook: #2d60c4;
+$color-twitter: #55acee;
+
+// Color applications
+$color-link-underline: $color-blue-light;
+
+// UI colors
+$color-error: #f51c1c;

--- a/static/sass/1-settings/_fonts.scss
+++ b/static/sass/1-settings/_fonts.scss
@@ -1,0 +1,18 @@
+// Font families
+$font-family-primary: 'PT Serif', Georgia, serif;
+$font-family-secondary: 'Open Sans', 'Helvetica Neue', Helvetica, Arial,
+  sans-serif;
+
+// Font root sizes
+$font-root: 16px;
+$font-root-tablet: 16px;
+$font-root-mobile: 15px;
+
+// Silent class helpers
+%font-serif {
+  font-family: $font-family-primary;
+}
+
+%font-sansserif {
+  font-family: $font-family-secondary;
+}

--- a/static/sass/2-tools/_all.scss
+++ b/static/sass/2-tools/_all.scss
@@ -1,0 +1,3 @@
+// TOOLS - Mixins and functions
+// Note: Should not output CSS
+@import 'mq';

--- a/static/sass/2-tools/_mq.scss
+++ b/static/sass/2-tools/_mq.scss
@@ -1,0 +1,292 @@
+// SASS-MQ - Developed by The Guardian
+// Docs: https://github.com/sass-mq/sass-mq
+
+@charset 'UTF-8'; // Fixes an issue where Ruby locale is not set properly
+                  // See https://github.com/sass-mq/sass-mq/pull/10
+
+/// Base font size on the `<body>` element
+/// @type Number (unit)
+$mq-base-font-size: 16px !default;
+
+/// Responsive mode
+///
+/// Set to `false` to enable support for browsers that do not support @media queries,
+/// (IE <= 8, Firefox <= 3, Opera <= 9)
+///
+/// You could create a stylesheet served exclusively to older browsers,
+/// where @media queries are rasterized
+///
+/// @example scss
+///  // old-ie.scss
+///  $mq-responsive: false;
+///  @import 'main'; // @media queries in this file will be rasterized up to $mq-static-breakpoint
+///                   // larger breakpoints will be ignored
+///
+/// @type Boolean
+/// @link https://github.com/sass-mq/sass-mq#responsive-mode-off Disabled responsive mode documentation
+$mq-responsive: true !default;
+
+/// Breakpoint list
+///
+/// Name your breakpoints in a way that creates a ubiquitous language
+/// across team members. It will improve communication between
+/// stakeholders, designers, developers, and testers.
+///
+/// @type Map
+/// @link https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint Full documentation and examples
+$mq-breakpoints: (
+    mobile:  320px,
+    tablet:  740px,
+    desktop: 980px,
+    wide:    1300px
+) !default;
+
+/// Static breakpoint (for fixed-width layouts)
+///
+/// Define the breakpoint from $mq-breakpoints that should
+/// be used as the target width for the fixed-width layout
+/// (i.e. when $mq-responsive is set to 'false') in a old-ie.scss
+///
+/// @example scss
+///  // tablet-only.scss
+///  //
+///  // Ignore all styles above tablet breakpoint,
+///  // and fix the styles (e.g. layout) at tablet width
+///  $mq-responsive: false;
+///  $mq-static-breakpoint: tablet;
+///  @import 'main'; // @media queries in this file will be rasterized up to tablet
+///                   // larger breakpoints will be ignored
+///
+/// @type String
+/// @link https://github.com/sass-mq/sass-mq#adding-custom-breakpoints Full documentation and examples
+$mq-static-breakpoint: desktop !default;
+
+/// Show breakpoints in the top right corner
+///
+/// If you want to display the currently active breakpoint in the top
+/// right corner of your site during development, add the breakpoints
+/// to this list, ordered by width, e.g. (mobile, tablet, desktop).
+///
+/// @type map
+$mq-show-breakpoints: () !default;
+
+/// Customize the media type (e.g. `@media screen` or `@media print`)
+/// By default sass-mq uses an "all" media type (`@media all and …`)
+///
+/// @type String
+/// @link https://github.com/sass-mq/sass-mq#changing-media-type Full documentation and examples
+$mq-media-type: all !default;
+
+/// Convert pixels to ems
+///
+/// @param {Number} $px - value to convert
+/// @param {Number} $base-font-size ($mq-base-font-size) - `<body>` font size
+///
+/// @example scss
+///  $font-size-in-ems: mq-px2em(16px);
+///  p { font-size: mq-px2em(16px); }
+///
+/// @requires $mq-base-font-size
+/// @returns {Number}
+@function mq-px2em($px, $base-font-size: $mq-base-font-size) {
+  @if unitless($px) {
+      @warn 'Assuming #{$px} to be in pixels, attempting to convert it into pixels.';
+      @return mq-px2em($px * 1px, $base-font-size);
+  } @else if unit($px) == em {
+      @return $px;
+  }
+  @return ($px / $base-font-size) * 1em;
+}
+
+/// Get a breakpoint's width
+///
+/// @param {String} $name - Name of the breakpoint. One of $mq-breakpoints
+///
+/// @example scss
+///  $tablet-width: mq-get-breakpoint-width(tablet);
+///  @media (min-width: mq-get-breakpoint-width(desktop)) {}
+///
+/// @requires {Variable} $mq-breakpoints
+///
+/// @returns {Number} Value in pixels
+@function mq-get-breakpoint-width($name, $breakpoints: $mq-breakpoints) {
+  @if map-has-key($breakpoints, $name) {
+      @return map-get($breakpoints, $name);
+  } @else {
+      @warn "Breakpoint #{$name} wasn't found in $breakpoints.";
+  }
+}
+
+/// Media Query mixin
+///
+/// @param {String | Boolean} $from (false) - One of $mq-breakpoints
+/// @param {String | Boolean} $until (false) - One of $mq-breakpoints
+/// @param {String | Boolean} $and (false) - Additional media query parameters
+/// @param {String} $media-type ($mq-media-type) - Media type: screen, print…
+///
+/// @ignore Undocumented API, for advanced use only:
+/// @ignore @param {Map} $breakpoints ($mq-breakpoints)
+/// @ignore @param {String} $static-breakpoint ($mq-static-breakpoint)
+///
+/// @content styling rules, wrapped into a @media query when $responsive is true
+///
+/// @requires {Variable} $mq-media-type
+/// @requires {Variable} $mq-breakpoints
+/// @requires {Variable} $mq-static-breakpoint
+/// @requires {function} mq-px2em
+/// @requires {function} mq-get-breakpoint-width
+///
+/// @link https://github.com/sass-mq/sass-mq#responsive-mode-on-default Full documentation and examples
+///
+/// @example scss
+///  .element {
+///    @include mq($from: mobile) {
+///      color: red;
+///    }
+///    @include mq($until: tablet) {
+///      color: blue;
+///    }
+///    @include mq(mobile, tablet) {
+///      color: green;
+///    }
+///    @include mq($from: tablet, $and: '(orientation: landscape)') {
+///      color: teal;
+///    }
+///    @include mq(950px) {
+///      color: hotpink;
+///    }
+///    @include mq(tablet, $media-type: screen) {
+///      color: hotpink;
+///    }
+///    // Advanced use:
+///    $my-breakpoints: (L: 900px, XL: 1200px);
+///    @include mq(L, $breakpoints: $my-breakpoints, $static-breakpoint: L) {
+///      color: hotpink;
+///    }
+///  }
+@mixin mq(
+  $from: false,
+  $until: false,
+  $and: false,
+  $media-type: $mq-media-type,
+  $breakpoints: $mq-breakpoints,
+  $responsive: $mq-responsive,
+  $static-breakpoint: $mq-static-breakpoint
+) {
+  $min-width: 0;
+  $max-width: 0;
+  $media-query: '';
+
+  // From: this breakpoint (inclusive)
+  @if $from {
+      @if type-of($from) == number {
+          $min-width: mq-px2em($from);
+      } @else {
+          $min-width: mq-px2em(mq-get-breakpoint-width($from, $breakpoints));
+      }
+  }
+
+  // Until: that breakpoint (exclusive)
+  @if $until {
+      @if type-of($until) == number {
+          $max-width: mq-px2em($until);
+      } @else {
+          $max-width: mq-px2em(mq-get-breakpoint-width($until, $breakpoints)) - .01em;
+      }
+  }
+
+  // Responsive support is disabled, rasterize the output outside @media blocks
+  // The browser will rely on the cascade itself.
+  @if $responsive == false {
+      $static-breakpoint-width: mq-get-breakpoint-width($static-breakpoint, $breakpoints);
+      $target-width: mq-px2em($static-breakpoint-width);
+
+      // Output only rules that start at or span our target width
+      @if (
+          $and == false
+          and $min-width <= $target-width
+          and (
+              $until == false or $max-width >= $target-width
+          )
+      ) {
+          @content;
+      }
+  } @else {
+    // Responsive support is enabled, output rules inside @media queries
+      @if $min-width != 0 { $media-query: '#{$media-query} and (min-width: #{$min-width})'; }
+      @if $max-width != 0 { $media-query: '#{$media-query} and (max-width: #{$max-width})'; }
+      @if $and            { $media-query: '#{$media-query} and #{$and}'; }
+
+      // Remove unnecessary media query prefix 'all and '
+      @if ($media-type == 'all' and $media-query != '') {
+          $media-type: '';
+          $media-query: str-slice(unquote($media-query), 6);
+      }
+
+      @media #{$media-type + $media-query} {
+          @content;
+      }
+  }
+}
+
+/// Add a breakpoint
+///
+/// @param {String} $name - Name of the breakpoint
+/// @param {Number} $width - Width of the breakpoint
+///
+/// @requires {Variable} $mq-breakpoints
+///
+/// @example scss
+///  @include mq-add-breakpoint(tvscreen, 1920px);
+///  @include mq(tvscreen) {}
+@mixin mq-add-breakpoint($name, $width) {
+  $new-breakpoint: ($name: $width);
+  $mq-breakpoints: map-merge($mq-breakpoints, $new-breakpoint) !global;
+}
+
+/// Show the active breakpoint in the top right corner of the viewport
+/// @link https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint
+///
+/// @param {List} $show-breakpoints ($mq-show-breakpoints) - List of breakpoints to show in the top right corner
+/// @param {Map} $breakpoints ($mq-breakpoints) - Breakpoint names and sizes
+///
+/// @requires {Variable} $mq-breakpoints
+/// @requires {Variable} $mq-show-breakpoints
+///
+/// @example scss
+///  // Show breakpoints using global settings
+///  @include mq-show-breakpoints;
+///
+///  // Show breakpoints using custom settings
+///  @include mq-show-breakpoints((L, XL), (S: 300px, L: 800px, XL: 1200px));
+@mixin mq-show-breakpoints($show-breakpoints: $mq-show-breakpoints, $breakpoints: $mq-breakpoints) {
+  $color-test-1: #FCF8E3;
+  $color-test-2: #FBEED5;
+  $color-test-3: #C09853;
+
+  body:before {
+    background-color: $color-test-1;
+    border-bottom: 1px solid $color-test-2;
+    border-left: 1px solid $color-test-2;
+    color: $color-test-3;
+    font: small-caption;
+    padding: 3px 6px;
+    pointer-events: none;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 100;
+
+    // Loop through the breakpoints that should be shown
+    @each $show-breakpoint in $show-breakpoints {
+      $width: mq-get-breakpoint-width($show-breakpoint, $breakpoints);
+      @include mq($show-breakpoint, $breakpoints: $breakpoints) {
+        content: "#{$show-breakpoint} ≥ #{$width} (#{mq-px2em($width)})";
+      }
+    }
+  }
+}
+
+@if length($mq-show-breakpoints) > 0 {
+  @include mq-show-breakpoints;
+}

--- a/static/sass/3-generic/_all.scss
+++ b/static/sass/3-generic/_all.scss
@@ -1,0 +1,3 @@
+// GENERIC - Resets to default browser styles
+@import 'box-sizing';
+@import 'normalize';

--- a/static/sass/3-generic/_box-sizing.scss
+++ b/static/sass/3-generic/_box-sizing.scss
@@ -1,0 +1,10 @@
+// Apply a natural box layout model to all elements, but allowing components to change
+// @link: https://www.paulirish.com/2012/box-sizing-border-box-ftw/
+html {
+  box-sizing: border-box;
+}
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}

--- a/static/sass/3-generic/_normalize.scss
+++ b/static/sass/3-generic/_normalize.scss
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: inherit;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/static/sass/4-elements/_all.scss
+++ b/static/sass/4-elements/_all.scss
@@ -1,0 +1,66 @@
+// ELEMENTS - Raw tag styles
+
+// Set font root sizes for desktop, tablet, mobile
+html {
+  font-size: $font-root;
+  @extend %font-serif;
+  @include mq($until: bp-s) {
+    font-size: $font-root-mobile;
+  }
+}
+
+// Strip margin and padding from all headers a paragraphs
+html,
+body,
+dd,
+dl,
+div,
+dt,
+ul,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin: 0;
+  padding: 0;
+}
+
+// Set base typography proportions for headers, paragraphs, etc.
+// sizing variables in settings/_breakpoints.scss
+h1 {
+  @extend %font-sansserif;
+  font-size: $size-xxl;
+  line-height: 1.2;
+}
+
+h2 {
+  @extend %font-sansserif;
+  font-size: $size-xl;
+}
+
+h3 {
+  @extend %font-sansserif;
+  font-size: $size-l;
+}
+
+h4 {
+  @extend %font-sansserif;
+  font-size: $size-m;
+}
+
+h5 {
+  @extend %font-sansserif;
+  font-size: $size-s;
+}
+
+p {
+  font-size: $size-b;
+}
+
+// We want all of our cite elements to not be italicized
+cite {
+  font-style: normal;
+}

--- a/static/sass/4-elements/_all.scss
+++ b/static/sass/4-elements/_all.scss
@@ -3,7 +3,7 @@
 // Set font root sizes for desktop, tablet, mobile
 html {
   font-size: $font-root;
-  @extend %font-serif;
+  font-family: $font-family-secondary;
   @include mq($until: bp-s) {
     font-size: $font-root-mobile;
   }
@@ -31,28 +31,23 @@ p {
 // Set base typography proportions for headers, paragraphs, etc.
 // sizing variables in settings/_breakpoints.scss
 h1 {
-  @extend %font-sansserif;
   font-size: $size-xxl;
   line-height: 1.2;
 }
 
 h2 {
-  @extend %font-sansserif;
   font-size: $size-xl;
 }
 
 h3 {
-  @extend %font-sansserif;
   font-size: $size-l;
 }
 
 h4 {
-  @extend %font-sansserif;
   font-size: $size-m;
 }
 
 h5 {
-  @extend %font-sansserif;
   font-size: $size-s;
 }
 

--- a/static/sass/5-objects/_all.scss
+++ b/static/sass/5-objects/_all.scss
@@ -1,0 +1,8 @@
+// OBJECTS - First layer of class-based selectors; defines undecorated design patterns
+// @todo - get rid of lines and fontawesome
+@import 'fontawesome';
+@import 'grid';
+@import 'images';
+@import 'lines';
+@import 'links';
+@import 'typography';

--- a/static/sass/5-objects/_fontawesome.scss
+++ b/static/sass/5-objects/_fontawesome.scss
@@ -1,0 +1,175 @@
+/*!
+ *  Font Awesome 4.4.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+ */
+/* FONT PATH
+ * -------------------------- */
+
+// Note: To be deleted after SVG icon replacement
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.eot');
+  src: url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.eot') format('embedded-opentype'), url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.woff2') format('woff2'), url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.woff') format('woff'), url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.ttf') format('truetype'), url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/fonts/fontawesome-webfont.svg') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+.fa {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* makes the font 33% larger relative to the icon container */
+.fa-lg {
+  font-size: 1.33333333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+
+.fa-bars:before {
+  content: "\f0c9";
+}
+
+/* Icons we use */
+/* Move icons up here and uncomment as they're used */
+.fa-mail-forward:before,
+.fa-share:before {
+  content: "\f064";
+}
+
+// Brand Icons
+.fa-twitter:before {
+  content: "\f099";
+}
+.fa-facebook-f:before,
+.fa-facebook:before {
+  content: "\f09a";
+}
+.fa-instagram:before {
+  content: "\f16d";
+}
+.fa-linkedin:before {
+  content: "\f0e1";
+}
+.fa-youtube:before {
+  content: "\f167";
+}
+.fa-google-plus:before {
+  content: "\f0d5";
+}
+.fa-reddit:before {
+  content: "\f1a1";
+}
+.fa-apple:before {
+  content: "\f179";
+}
+.fa-google:before {
+  content: "\f1a0";
+}
+
+// Related Documents
+.fa-file-text-o:before {
+  content: "\f0f6";
+}
+
+// Email Icon
+.fa-envelope:before {
+  content: "\f0e0";
+}
+
+// Telephone
+.fa-phone:before {
+  content: "\f095";
+}
+
+// Comments Icons
+.fa-comments-o:before {
+  content: "\f0e6";
+}
+.fa-comments:before {
+  content: "\f086";
+}
+
+// Search Bar
+.fa-search:before {
+  content: "\f002";
+}
+
+// Toggle Carets
+.fa-caret-down:before {
+  content: "\f0d7";
+}
+.fa-caret-right:before {
+  content: "\f0da";
+}
+
+// Form <select>
+.fa-chevron-down:before {
+  content: "\f078";
+}
+
+.fa-angle-double-right:before {
+  content: "\f101";
+}
+
+// Back to top
+.fa-arrow-up:before {
+  content: "\f062";
+}
+
+// Direction Arrows
+.fa-long-arrow-left:before {
+  content: "\f177";
+}
+.fa-long-arrow-right:before {
+  content: "\f178";
+}
+
+// Close X
+// .fa-remove:before,
+// .fa-times:before,
+.fa-close:before {
+  content: "\f00d";
+}
+
+// Photo Credit
+.fa-camera:before {
+  content: "\f030";
+}
+
+.fa-feed:before,
+.fa-rss:before {
+  content: "\f09e";
+}
+
+.fa-map-marker:before {
+  content: "\f041";
+}
+
+.fa-user:before {
+  content: "\f007";
+}
+
+// Account Link
+.fa-user:before {
+  content: "\f007";
+}
+
+//Subscribe page
+.fa-reddit:before {
+  content: "\f1a1";
+}
+.fa-external-link:before {
+  content: "\f08e";
+}
+
+.fa-check:before {
+  content: "\f00c";
+}
+
+.fa-star:before {
+  content: "\f005";
+}

--- a/static/sass/5-objects/_grid.scss
+++ b/static/sass/5-objects/_grid.scss
@@ -1,0 +1,321 @@
+$grid-columns: 12;
+$grid-gutter: $size-b;
+$grid-gutter-px: 17.6;
+$grid-size-list: (
+  (s, bp-s, $bp-s),
+  (m, bp-m, $bp-m),
+  (l, bp-l, $bp-l),
+  (xl, bp-xl,$bp-xl),
+  (xxl, bp-xxl, $bp-xxl)
+);
+$column-slug: col !default;
+
+@function get-col-percent($column-num) {
+  @return percentage($column-num / $grid-columns);
+}
+
+@function omega($column-num) {
+  @return $grid-gutter-px - ($grid-gutter-px / ($grid-columns/$column-num)) + 'px';
+}
+
+%flex-grid {
+  display: flex;
+
+  > :last-child {
+    margin-right: 0;
+  }
+}
+
+%flex-col {
+  flex: 0 1 100%;
+  margin-right: $grid-gutter;
+  max-width: 100%;
+}
+
+.col {
+  @extend %flex-col;
+
+  // .col_inline
+  // allow flex items to auto-size rather than fill available width
+  &_inline {
+    flex: 0 1 auto;
+    margin-right: $grid-gutter;
+  }
+}
+
+// .col_{$i}
+@for $i from 1 through $grid-columns {
+  // Create extension for column sizes 1-12
+  // It would be ideal to put the width as the third value in the flex property
+  // but IE 10 and 11 don't like that if it involves calc():
+  // https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc
+  %#{$column-slug}_#{$i} {
+    flex: 0 1 auto;
+    margin-right: $grid-gutter;
+    overflow: hidden;
+    width: calc(#{get-col-percent($i)} - #{omega($i)});
+  }
+
+  // Create column class that resets to full width at bp-l
+  .#{$column-slug}_#{$i} {
+    @extend %#{$column-slug}_#{$i};
+  }
+}
+
+.col_adunit300x250 {
+  @extend %flex-col;
+  margin-right: 0;
+  max-width: 310px;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+
+  &_container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $bp-default;
+  }
+
+  // .grid_row
+  // force flex items into a row
+  &_row {
+    @extend %flex-grid;
+    flex-wrap: nowrap;
+  }
+
+  // .grid_padded -- DEFAULT
+  // adds left/right padding on small screens
+  &_padded {
+    padding: 0 $size-xs;
+
+    @include mq($from: bp-m, $until: bp-xl) {
+      padding: 0 $size-b;
+    }
+
+    @include mq($from: bp-xl) {
+      padding: 0
+    }
+  }
+
+  // Custom setting for story page lead art
+  // adds left/right padding on middle-size screens
+  &_padded--temp {
+    padding: 0;
+
+    @include mq($from: bp-l, $until: bp-xl) {
+      padding: 0 $size-b;
+    }
+  }
+
+  // .grid_separator
+  // adds margin-bottom to separate elements
+  &_separator {
+    margin-bottom: $grid-gutter;
+  }
+
+  &_separator--xs {
+    margin-bottom: $grid-gutter/4;
+  }
+
+  &_separator--s {
+    margin-bottom: $grid-gutter/2;
+  }
+
+  &_separator--l {
+    margin-bottom: $size-xl;
+  }
+  &_separator--xl {
+    margin-bottom: $size-xxl;
+  }
+
+  &_order {
+    &--primary {
+      order: -1;
+    }
+
+    &--secondary {
+      order: 1;
+    }
+  }
+}
+
+@each $size, $bp, $width in $grid-size-list {
+  // Set column size from a breakpoint
+  // .small--6 sets 6/12 columns from bp-s onward
+  @for $i from 1 through $grid-columns {
+    .col_#{$i}--#{$size} {
+      @include mq($from: $bp) {
+        flex: 0 1 auto;
+        margin-right: $grid-gutter;
+        overflow: hidden;
+        width: calc(#{get-col-percent($i)} - #{omega($i)});
+      }
+    }
+  }
+
+  // Set max container width based on breakpoint sizes
+  .grid_container--#{$size} {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $width;
+  }
+
+  .grid_separator--until_#{$size} {
+    @include mq($until: $bp) {
+      margin-bottom: $grid-gutter;
+    }
+  }
+
+  .grid_row--until_#{$size} {
+    @include mq($until: $bp) {
+      display: flex;
+      flex-wrap: nowrap;
+
+      > :last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .grid_row--from_#{$size} {
+    @include mq($from: $bp) {
+      display: flex;
+      flex-wrap: nowrap;
+
+      > :last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .grid_row--m_to_l {
+    @include mq($from: $bp-m, $until: $bp-l) {
+      display: flex;
+      flex-wrap: nowrap;
+
+      > :last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  /**
+    Use the following two classes in tandem,
+    probably with .col and .col_adunit300x250
+    together in a row. It flips the order
+    at different breakpoints, which can be
+    useful when stacking.
+  */
+  .grid_order--secondary--until_#{$size} {
+    order: 1;
+
+    @include mq($until: $bp) {
+      order: 2;
+    }
+  }
+
+  .grid_order--primary--until_#{$size} {
+    order: 2;
+
+    @include mq($until: $bp) {
+      order: 1;
+    }
+  }
+
+  // .grid_wrap
+  // allow items in a grid_row to wrap until a breakpoint
+  .grid_wrap--#{$size} {
+    @include mq($until: $bp) {
+      flex-wrap: wrap;
+
+      @for $i from 1 through $grid-columns {
+        > .#{$column-slug}_#{$i},
+        > .col {
+          flex: 0 1 100%;
+          margin-right: 0;
+          max-width: 100%;
+        }
+      }
+    }
+
+    &.grid_wrap--reverse {
+      @include mq($until: $bp) {
+        flex-wrap: wrap-reverse;
+
+        @for $i from 1 through $grid-columns {
+          > .#{$column-slug}_#{$i},
+          > .col {
+            flex: 0 1 100%;
+            margin-right: 0;
+            max-width: 100%;
+          }
+        }
+      }
+    }
+
+    .col_adunit300x250 {
+      flex: 0 1 100%;
+      margin-right: 0;
+      max-width: 100%;
+
+      @include mq($from: $bp) {
+        margin-left: 0;
+        margin-right: 0;
+        max-width: 310px;
+      }
+    }
+  }
+
+  // Set left/right padded until a breakpoint
+  // grid_padded--m = 1.1rem padding until bp-m
+  .grid_padded--#{$size} {
+    @include mq($until: $bp-xs) {
+      padding: 0 $size-xs;
+    }
+
+    @include mq($until: $bp) {
+      padding: 0 $size-b;
+    }
+  }
+
+  // Hide element screens > $bp
+  // i.e. display until $bp
+  .hide_from {
+    &--#{$size} {
+      @include mq($from: $bp) {
+        display: none !important;
+      }
+    }
+  }
+
+  // Hide element screens < $bp
+  // i.e. display from $bp
+  .hide_until {
+    &--#{$size} {
+      @include mq($until: $bp) {
+        display: none !important;
+      }
+    }
+  }
+
+  &--left_until--#{$size} {
+    @include mq($from: $bp) {
+      order: -2;
+    }
+  }
+}
+
+.col_omega {
+  margin-right: 0;
+}
+
+// General body class to prevent horizontal scrolling
+.tt_body {
+  overflow-x: hidden;
+}
+
+.grid_separator--extra {
+  margin: $size-b*4 0;
+}

--- a/static/sass/5-objects/_images.scss
+++ b/static/sass/5-objects/_images.scss
@@ -1,0 +1,80 @@
+// <figure>
+.image_default {
+  margin: 0;
+
+  img {
+    width: 100%;
+  }
+}
+
+// <figcaption>
+.image_default--caption {
+  @extend %font-sansserif;
+  @extend %link--blue;
+  background-color: $color-white-off;
+  color: $color-gray-dark;
+  font-size: $size-xs;
+  margin-top: -5px;
+  padding: $size-xs;
+
+  p {
+    @extend %font-sansserif;
+    font-size: $size-xs;
+    margin: 0;
+    i {
+      color: lighten($color-gray-medium, 20%);
+    }
+  }
+}
+
+.photo_caption--small {
+  @extend %font-sansserif;
+  color: $color-gray-dark;
+  font-size: $size-xxs;
+
+  cite {
+    display: block;
+    font-size: $size-xxs;
+    margin-bottom: $size-b/4;
+
+    @include mq($from: bp-m) {
+      margin-top: $size-b/4;
+    }
+  }
+
+  cite p {
+    display: none;
+  }
+
+  i {
+    color: lighten($color-gray-medium, 20%);
+  }
+}
+
+.js-lazy-image {
+  .no-js & {
+    display: none;
+  }
+
+  &,
+  &--loading,
+  &--loaded {
+    backface-visibility: hidden;
+  }
+
+  &,
+  &--loading {
+    opacity: 0.1;
+
+    @supports (filter: blur(10px)) {
+      filter: blur(10px);
+      opacity: 0.5;
+    }
+  }
+
+  &--loaded {
+    filter: none;
+    opacity: 1;
+    transition: opacity 0.5s;
+  }
+}

--- a/static/sass/5-objects/_lines.scss
+++ b/static/sass/5-objects/_lines.scss
@@ -1,0 +1,4 @@
+//Turn this into a true util file with a mixin.
+.border_bottom--yellow {
+  border-bottom: 2px solid $color-yellow-tribune;
+}

--- a/static/sass/5-objects/_links.scss
+++ b/static/sass/5-objects/_links.scss
@@ -1,0 +1,77 @@
+.link--teal,
+%link--teal {
+  a {
+    color: $color-teal-gray;
+    font-weight: 700;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+  }
+}
+.link--blue,
+%link--blue {
+  a {
+    border-bottom: 1px solid $color-blue-light;
+    box-shadow: inset 0 -1px 0 0 $color-blue-light;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      border-bottom: 1px solid $color-teal-gray;
+      box-shadow: inset 0 -2px 0 0 $color-teal-gray;
+      color: inherit;
+      text-decoration: none;
+      transition: all .8s ease;
+    }
+  }
+
+  .unlink {
+    border: 0;
+    box-shadow: none;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      border: 0;
+      text-decoration: none;
+    }
+  }
+}
+
+.link--blue_subtle,
+%link--blue_subtle {
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      border-bottom: 1px solid $color-blue-light;
+      box-shadow: inset 0 -1px 0 0 $color-blue-light;
+      text-decoration: none;
+    }
+  }
+}
+
+
+%link--hover_animation {
+  display: inline-block;
+  text-decoration: none;
+
+  &:after {
+    display:block;
+    content: '';
+    padding-bottom: $size-b/2;
+    border-bottom: solid 3px $color-blue-light;
+    transform: scaleX(0);
+    transition: transform 150ms ease-in-out;
+  }
+
+  &:hover:after {
+    transform: scaleX(1);
+  }
+}

--- a/static/sass/5-objects/_typography.scss
+++ b/static/sass/5-objects/_typography.scss
@@ -1,0 +1,99 @@
+.prose {
+  p {
+    @extend %font-serif;
+    @extend %link--blue;
+    color: $color-black-off;
+    line-height: 1.4;
+    margin: $size-b 0;
+
+    &:first-of-type {
+      margin: 0 0 $size-b;
+    }
+  }
+}
+
+// Smallhead: <h5>
+// Examples: Mini-headers, byline & button text
+.smallcaps {
+  @extend %font-sansserif;
+  color: $color-black-pure;
+  font-weight: 700;
+  letter-spacing: .03em;
+  padding: .2em 0;
+  text-transform: uppercase;
+
+  // Byline
+  &--light {
+    @extend %font-sansserif;
+    color: $color-gray-medium;
+    font-size: $size-xs;
+    font-weight: 400;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+
+    @include mq($until: bp-l) {
+      font-size: $size-s;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+
+      &:active,
+      &:hover {
+        color: $color-teal-gray;
+        text-decoration: none;
+      }
+    }
+  }
+
+  &--teal {
+    @extend .smallcaps;
+    color: $color-teal-gray;
+  }
+
+  &--white {
+    @extend .smallcaps;
+    color: $color-white-pure;
+    letter-spacing: .05em;
+  }
+
+  &--section {
+    @extend .smallcaps--light;
+    font-size: $size-s;
+    margin-bottom: $size-b/4;
+  }
+
+  &--section__header {
+    @extend .smallcaps--light;
+    border-top: 2px solid $color-black-off;
+    color: $color-gray-dark;
+    font-size: $size-s;
+    padding-top: $size-b/4;
+  }
+}
+
+// Subtext: <p>
+// Examples: Grayed text below smallcaps, comment policy
+.subtext {
+  @extend %font-sansserif;
+  @extend %link--blue;
+  color: $color-gray-medium;
+  font-size: $size-xs;
+  font-weight: 400;
+  padding: 0;
+}
+
+.list--bulleted {
+  @extend %font-serif;
+
+  li {
+    font-size: $size-b;
+    margin: 0 0 $size-b $size-m;
+    @extend %link--blue;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/static/sass/6-components/_all.scss
+++ b/static/sass/6-components/_all.scss
@@ -1,0 +1,7 @@
+// COMPONENTS - Items scoped to custom ui element
+@import 'buttons';
+@import 'contact';
+@import 'footer';
+@import 'forms';
+@import 'hero';
+@import 'navbar';

--- a/static/sass/6-components/_buttons.scss
+++ b/static/sass/6-components/_buttons.scss
@@ -1,0 +1,298 @@
+// this styles buttons and links that are supposed to look like buttons
+// NOTE: if it's a literal <button>, anything inside it will automatically get vertically centered
+// if it's a link, you'll need to put a span element with class "vertical_center" inside it
+// that span element should contain any icons, text, etc.
+
+@mixin button(
+  $bg-color,
+  $icon-color: $color-white-pure,
+  $icon-size: $size-s,
+  $inverse-text: white,
+  $toggle: false,
+  $mobile-only: false,
+  $inverse: false
+) {
+  background-color: $bg-color;
+  border: $button-border-width solid $bg-color;
+  color: $color-white-pure;
+
+  i {
+    color: $icon-color;
+    font-size: $icon-size;
+  }
+
+  // if mobile only, no need for hover styles
+  @if not $mobile-only {
+    @if $inverse-text == black {
+      color: $color-black-off;
+
+      &:hover,
+      &:active {
+        background-color: $color-white-pure;
+        color: $color-black-off;
+
+        i {
+          color: $color-black-off;
+        }
+      }
+    } @else if $inverse {
+      &:hover,
+      &:active {
+        background-color: transparent;
+        color: $color-white-pure;
+
+        i {
+          color: $bg-color;
+        }
+      }
+    } @else {
+      &:hover,
+      &:active {
+        background-color: transparent;
+        color: $bg-color;
+
+        i {
+          color: $bg-color;
+        }
+      }
+    }
+  }
+
+  @if $toggle {
+    color: $color-black-pure;
+
+    &:hover,
+    &:active {
+      background-color: $bg-color;
+      color: $color-white-pure;
+    }
+
+    &.button_active {
+      background-color: $color-white-pure;
+      color: $color-black-pure;
+    }
+  }
+}
+
+// dark buttons in mobile nav are a bit shorter so nav doesn't change height on scroll
+$button-nav-height: 24px;
+$button-default-height: 26px;
+$button-large-height: 44px;
+$button-border-width: 2px;
+
+// FYI: Some "links" are styled to look like buttons
+// Links styled to look like links live in _links.scss
+// Base styles for buttons
+// Always include .button + specific button settings below
+// Any line-height values you see are for vertical centering
+$curve-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+.button {
+  @extend %font-sansserif;
+  @extend .smallcaps;
+  cursor: pointer;
+  font-size: $size-xxs;
+  font-weight: 700;
+  padding: 0 $size-b/2;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: background-color 500ms ease;
+  white-space: nowrap;
+
+  // Default Button style
+  // For user-input actions, i.e. "submit" or "search"
+  &--yellow {
+    @include button($color-yellow-tribune, $inverse-text: black);
+    display: inline-block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  // Default "Link" Button styles
+  // Teal buttons are not full width
+  &--teal {
+    @include button($color-teal-gray);
+    display: inline-block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--gray {
+    @include button($color-gray-dark);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--light_gray {
+    @include button($color-gray-light);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--white_off {
+    @include button(
+      $bg-color: $color-white-off,
+      $icon-color: $color-black-pure,
+      $inverse-text: black
+    );
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--light_gray-inverse {
+    @extend .smallcaps--teal;
+    background-color: $color-white-pure;
+    border-color: $color-white-off;
+    border-style: solid;
+    border-width: 2px;
+    cursor: pointer;
+    @extend %font-sansserif;
+    font-size: $size-xxs;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    padding: $size-b/4;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
+    white-space: nowrap;
+    width: 100%;
+
+    span {
+      background-color: $color-white-pure;
+      padding: 0 $size-xxs;
+    }
+
+    &:hover {
+      border-color: $color-gray-light;
+    }
+  }
+
+  // Default "social" button (Colored box w/ white bg on hover)
+  &--comments {
+    @include button($color-teal-gray);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--fb {
+    @include button($color-facebook);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--twitter {
+    @include button($color-twitter);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  &--email {
+    @include button($color-yellow-tribune);
+    display: block;
+    height: $button-default-height;
+    line-height: $button-default-height - $button-border-width;
+  }
+
+  // Alternate "dark" social button
+  // Ex: Sticky nav header on mobile
+  &--comments-dark {
+    @include button(
+      $bg-color: $color-black-off,
+      $icon-color: $color-teal-gray,
+      $icon-size: $size-b,
+      $mobile-only: true
+    );
+    display: block;
+    height: $button-nav-height;
+    line-height: $button-nav-height;
+  }
+
+  &--fb-dark {
+    @include button(
+      $bg-color: $color-black-off,
+      $icon-color: $color-facebook,
+      $icon-size: $size-b,
+      $mobile-only: true
+    );
+    display: block;
+    height: $button-nav-height;
+    line-height: $button-nav-height;
+  }
+
+  &--home {
+    @include button($bg-color: $color-black-off, $mobile-only: true);
+    display: block;
+    height: $button-nav-height;
+
+    img {
+      display: block;
+      max-height: $size-b;
+      max-width: 100%;
+    }
+  }
+
+  &--twitter-dark {
+    @include button(
+      $bg-color: $color-black-off,
+      $icon-color: $color-twitter,
+      $icon-size: $size-b,
+      $mobile-only: true
+    );
+    display: block;
+    height: $button-nav-height;
+    line-height: $button-nav-height;
+  }
+
+  &--email-dark {
+    @include button(
+      $bg-color: $color-black-off,
+      $icon-color: $color-yellow-tribune,
+      $icon-size: $size-b,
+      $mobile-only: true
+    );
+    display: block;
+    height: $button-nav-height;
+    line-height: $button-nav-height;
+  }
+
+  // Toggle buttons
+  // Ex: Republish story page "toggle" between HTML and Plain Text
+  &_toggle,
+  &_toggle--yellow {
+    @include button($color-yellow-tribune, $inverse-text: black, $toggle: true);
+    height: $button-default-height;
+  }
+
+  // for rare cases (like next/prev buttons on site search)
+  // where the link button classes are used on actual <button> elements
+  // in that case, vertical centering happens by default, so we override line-height
+  &.button--natural {
+    line-height: normal;
+  }
+
+  &.button--s {
+    font-size: $size-s;
+    height: 40px;
+    line-height: normal;
+    padding: $size-b/2 $size-s;
+  }
+
+  // Display options
+  &--titlecase {
+    text-transform: none;
+  }
+  &--l {
+    font-size: $size-xs;
+    padding: $size-xxs;
+    height: $button-large-height;
+    line-height: 20px;
+  }
+}

--- a/static/sass/6-components/_contact.scss
+++ b/static/sass/6-components/_contact.scss
@@ -1,0 +1,12 @@
+.contact {
+  @extend %link--blue;
+  p {
+    @extend %font-sansserif;
+    font-size: $size-s;
+  }
+  &--small {
+    p {
+      font-size: $size-xs;
+    }
+  }
+}

--- a/static/sass/6-components/_footer.scss
+++ b/static/sass/6-components/_footer.scss
@@ -1,0 +1,60 @@
+.site_footer {
+  @extend .print__hide;
+  background-color: $color-black-off;
+  padding: $size-b $size-b $size-giant;
+
+  &--logo {
+    margin: $size-xs 0 $size-giant;
+    max-width: 60px;
+  }
+
+  &--header {
+    @extend %font-sansserif;
+    color: $color-yellow-tribune;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    margin: $size-b/2 0;
+    text-align: left;
+    text-transform: uppercase;
+  }
+
+  .border--yellow_notch {
+    border-top: 2px solid $color-yellow-tribune;
+    margin: $size-xs 0;
+  }
+
+  // .col {
+  //   border-right: 1px solid $color-black-pure;
+  // }
+
+  ul {
+    list-style-type: none;
+  }
+
+  li {
+    clear: both;
+    padding: 2px 0;
+    text-align: left;
+  }
+
+  a {
+    @extend %font-sansserif;
+    color: $color-white-pure;
+    font-size: $size-xs;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &.donate {
+      color: $color-blue-light;
+      margin-top: $size-b;
+    }
+
+    i {
+      padding-right: $size-b;
+      width: $size-m;
+    }
+  }
+}

--- a/static/sass/6-components/_forms.scss
+++ b/static/sass/6-components/_forms.scss
@@ -1,0 +1,196 @@
+$color-error: #f51c1c;
+
+.form {
+  // text/email inputs
+  &__text {
+    &.invalid {
+      input {
+        border-color: $color-error;
+      }
+    }
+
+    input,
+    select {
+      @extend %font-sansserif;
+      background-color: #fbfbfb;
+      border: 1px solid $color-gray-light;
+      color: $color-black-pure;
+      display: block;
+      height: 45px;
+      padding: 0 0 0 $size-b;
+      width: 100%;
+    }
+
+    select {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+    }
+
+    label {
+      @extend %font-sansserif;
+      @extend .form__label;
+      @extend .grid_separator--xs;
+    }
+
+    // error message
+    p {
+      @extend .form__error;
+      @extend .form__error--normal;
+    }
+
+    &--standard {
+      input {
+        font-size: $size-b;
+        font-weight: normal;
+      }
+    }
+
+    &--heavy {
+      input {
+        font-size: $size-l;
+        font-weight: bold;
+      }
+    }
+  }
+
+  // error message
+  &__error {
+    color: $color-error;
+
+    &--normal {
+      font-size: $size-xs;
+    }
+
+    &--prominent {
+      border: 1px solid $color-error;
+      font-size: $size-s;
+      padding: $size-b;
+    }
+
+    &--centered {
+      text-align: center;
+    }
+  }
+
+  // generic label
+  &__label {
+    color: $color-gray-dark;
+    display: block;
+    font-size: $size-xs;
+    font-weight: bold;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    width: 100%;
+  }
+
+  // radio buttons (it's assumed they're inside an unordered list)
+  &__radios {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    list-style: none;
+
+    li {
+      align-items: center;
+      display: flex;
+      margin-bottom: $size-b;
+    }
+
+    label {
+      font-size: $size-b;
+    }
+
+    input {
+      margin-right: 5px;
+      margin-left: 1px;
+    }
+
+    &--serif {
+      label {
+        @extend %font-serif;
+      }
+    }
+
+    &--always-stack {
+      li {
+        flex: 1 1 100%;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    &--stack-at-medium {
+      @include mq($until: bp-m) {
+        li {
+          flex: 1 1 100%;
+        }
+      }
+    }
+  }
+
+  // fees checkbox and label
+  &__fees {
+    @extend .grid_row;
+    align-items: center;
+
+    input {
+      margin-right: $size-b/2;
+    }
+
+    label {
+      @extend .col_11;
+      font-size: $size-xs;
+    }
+
+    span {
+      font-weight: bold;
+    }
+  }
+
+  // Stripe native payment button
+  &__native {
+    div {
+      @extend .grid_separator--xs;
+    }
+
+    // link for going to manual pay
+    p {
+      @extend %link--teal;
+      font-size: $size-b;
+      text-align: center;
+    }
+  }
+
+  // Stripe card input
+  &__manual {
+    & > div {
+      background-color: #fbfbfb;
+      border: 1px solid $color-gray-light;
+      border-bottom-color: $color-yellow-tribune;
+      padding: $size-xxs;
+    }
+
+    &.invalid {
+      & > div {
+        border-color: $color-error;
+      }
+    }
+
+    // error message
+    & > p {
+      @extend .form__error;
+      @extend .form__error--normal;
+    }
+  }
+
+  // form submit button
+  &__submit {
+    width: 100%;
+
+    &:disabled {
+      opacity: 0.5;
+    }
+  }
+}

--- a/static/sass/6-components/_hero.scss
+++ b/static/sass/6-components/_hero.scss
@@ -1,0 +1,48 @@
+.hero {
+  background-position-y: 90%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  padding-bottom: $size-giant;
+  padding-top: $size-giant;
+  background-color: $color-black-pure;
+
+  &--business {
+    background-image: url('../img/TT-business-member-BG-test-bldg001.jpg');
+  }
+  &--circle {
+    background-image: url('../img/circle-bg.jpg');
+  }
+  p {
+    @extend %font-sansserif;
+  }
+
+  @include mq($until: bp-l) {
+    padding-bottom: $size-b;
+    padding-top: $size-b;
+  }
+
+  &__title {
+    border-bottom: 3px solid $color-yellow-tribune;
+    color: $color-white-pure;
+    font-size: $size-xl;
+    font-weight: 700;
+    padding-bottom: $size-b;
+
+    @include mq($from: bp-s) {
+      font-size: $size-giant;
+    }
+
+    @include mq($from: bp-xl) {
+      font-size: 3.5rem;
+    }
+  }
+
+  &__intro {
+    color: $color-white-pure;
+  }
+
+  &__cta {
+    color: $color-yellow-tribune;
+    font-weight: 700;
+  }
+}

--- a/static/sass/6-components/_navbar.scss
+++ b/static/sass/6-components/_navbar.scss
@@ -1,0 +1,253 @@
+.navbar {
+  @extend %font-sansserif;
+  background-color: $color-black-off;
+  justify-content: space-between;
+
+  .grid_row {
+    justify-content: space-between;
+  }
+
+  ul {
+    list-style-type: none;
+  }
+
+  &__col {
+    flex: 0 1 100%;
+    margin-right: $grid-gutter;
+    max-width: 100%;
+
+    @include mq($from: bp-l) {
+      flex: 0 1 auto;
+    }
+
+    &--halfsize {
+      @include mq($until: bp-l) {
+        max-width: 50%;
+        margin-right: 0;
+      }
+    }
+  }
+
+  &__logo {
+    order: -3;
+
+    @include mq($until: bp-l) {
+      flex: 0 1 100%;
+      max-width: 100%;
+    }
+
+    @include mq($from: bp-l) {
+      flex: 0 1 auto;
+      margin-right: $grid-gutter;
+      max-width: 100%;
+    }
+
+    &--link {
+      display: inline-block;
+      line-height: 1.85;
+      padding: $size-xxs 0 0;
+      width: 210px;
+
+      img {
+        height: 23px;
+      }
+    }
+
+    &--img {
+      max-width: 210px;
+      width: 100%;
+    }
+  }
+
+  &__divider {
+    color: $color-yellow-tribune;
+  }
+
+  &__divider,
+  &__item {
+    background-color: $color-black-off;
+    border: 0;
+    display: inline-block;
+    font-size: $size-xxs;
+    font-weight: 700;
+    letter-spacing: 0.07rem;
+    line-height: 1.85;
+    padding: $size-xxs 0 0;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  &__item {
+    color: $color-gray-light;
+
+    @include mq($until: bp-s) {
+      padding: 0.65rem 0 0;
+    }
+  }
+
+  &__item {
+    color: $color-gray-light;
+
+    &:hover {
+      color: $color-white-pure;
+    }
+
+    &.active {
+      color: $color-white-pure;
+
+      &:after {
+        border-bottom: solid 3px $color-yellow-tribune;
+        content: '';
+        display: block;
+        padding-bottom: $size-b/2;
+        transform: scaleX(1);
+      }
+    }
+  }
+
+  &__item {
+    &:after {
+      border-bottom: solid 3px $color-yellow-tribune;
+      content: '';
+      display: block;
+      padding-bottom: $size-b/2;
+      transform: scaleX(0);
+      transition: transform 150ms ease-in-out;
+    }
+
+    @include mq($from: bp-s) {
+      &:hover:after {
+        transform: scaleX(1);
+      }
+    }
+  }
+
+  &__right {
+    order: -2;
+
+    // Unique styles for navbar_thin
+    &.thin {
+      flex: 0 1 100%;
+      margin-right: 0;
+      max-width: 100%;
+
+      @include mq($from: bp-l) {
+        flex: 0 1 auto;
+        margin-right: 0;
+      }
+    }
+  }
+
+  .fa {
+    color: $color-yellow-tribune;
+    font-size: $size-s;
+  }
+
+  // These pixel hacks fix a rendering problem with how the icons overlap
+  .fa-bars {
+    margin-left: 2px;
+  }
+
+  .fa-search {
+    margin-left: 1px;
+  }
+
+  &__link {
+    text-transform: uppercase;
+
+    &:last-child {
+      margin-right: 0;
+      padding: 0;
+    }
+  }
+
+  &__list {
+    position: relative;
+
+    .navbar__link {
+      padding: 0 $size-b/2 0 0;
+
+      &:last-child {
+        padding: 0;
+      }
+    }
+  }
+
+  &__search {
+    background-color: $color-black-off;
+    justify-content: flex-end;
+
+    @include mq($from: bp-l) {
+      position: relative;
+    }
+
+    &--input {
+      @extend %font-sansserif;
+      background-color: $color-black-off;
+      border: none;
+      color: $color-gray-light;
+    }
+
+    input[type='text']:focus,
+    textarea:focus {
+      outline: none;
+    }
+
+    &--form {
+      background-color: $color-black-off;
+      left: 0;
+      position: absolute;
+      width: 100%;
+
+      @include mq($until: bp-l) {
+        padding: 0 $size-s;
+      }
+    }
+
+    &--btn {
+      float: right;
+    }
+
+    // Unique styles for navbar_thin
+    &.thin {
+      margin-right: 0;
+      position: initial;
+
+      @include mq($until: bp-l) {
+        order: -2;
+        width: 100%;
+      }
+
+      .navbar__search--form {
+        @include mq($until: bp-l) {
+          position: relative;
+        }
+      }
+
+      .navbar__search--btn {
+        float: none;
+      }
+    }
+  }
+}
+
+.tt_logo {
+  margin: $size-xl 0;
+
+  &__tagline {
+    @extend %font-sansserif;
+    font-size: $size-s;
+    font-weight: 700;
+    line-height: 1.2;
+    text-align: right;
+
+    a {
+      color: $color-teal-gray;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/static/sass/7-overrides/_all.scss
+++ b/static/sass/7-overrides/_all.scss
@@ -1,0 +1,2 @@
+// OVERRIDES - Highly specific utility classes
+@import 'helpers.scss';

--- a/static/sass/7-overrides/_helpers.scss
+++ b/static/sass/7-overrides/_helpers.scss
@@ -1,0 +1,128 @@
+.section-padding {
+  padding-bottom: $size-xl;
+  padding-top: $size-xl;
+}
+
+// Standard clearfix to clear floats/grid
+.clearfix,
+.clear {
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+}
+
+// Don't rename these classes without running regex-replace to catch usage in stories
+.float {
+  &_left,
+  &_right {
+    width: 50%;
+
+    @include mq($until: bp-s) {
+      width: 100%;
+    }
+  }
+
+  &_left {
+    float: left;
+    margin: 0 $size-s $size-s 0;
+  }
+
+  &_right {
+    float: right;
+    margin: 0 0 $size-s $size-s;
+  }
+}
+
+// apply to an element inside a parent that has position: relative
+.vertical_center {
+  left: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  z-index: 1;
+}
+
+// apply directly to an element assuming it has display: block
+.horizontal_center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.text {
+  &__center {
+    text-align: center;
+  }
+
+  &__left {
+    text-align: left;
+  }
+
+  &__right {
+    text-align: right;
+  }
+}
+
+.hidden {
+  display: none !important;
+}
+
+.print {
+  &__hide {
+    @media print {
+      display: none !important;
+    }
+  }
+  &__show {
+    @media print {
+      display: block !important;
+    }
+  }
+}
+
+.border {
+  &--yellow {
+    &_bottom {
+      border-bottom: 3px solid $color-yellow-tribune;
+    }
+
+    &_left {
+      border-left: 3px solid $color-yellow-tribune;
+      padding-left: $size-b;
+    }
+
+    &_right {
+      border-right: 3px solid $color-yellow-tribune;
+      padding-right: $size-b;
+    }
+
+    // Small yellow separator, often used under headers
+    &_notch {
+      border-top: 5px solid $color-yellow-tribune;
+      clear: both;
+      color: $color-yellow-tribune;
+      height: 0;
+      margin-bottom: $size-b;
+      text-align: left;
+      width: 40px;
+    }
+
+    // Small yellow separator, often used under headers
+    &_smallnotch {
+      border-top: 3px solid $color-yellow-tribune;
+      clear: both;
+      color: $color-yellow-tribune;
+      height: 0;
+      margin-bottom: $size-xxs;
+      text-align: left;
+      width: 25px;
+    }
+  }
+}
+
+.cta__box {
+  background-color: $color-sand;
+  padding: $size-b;
+}

--- a/static/sass/7-overrides/_helpers.scss
+++ b/static/sass/7-overrides/_helpers.scss
@@ -75,11 +75,6 @@
       display: none !important;
     }
   }
-  &__show {
-    @media print {
-      display: block !important;
-    }
-  }
 }
 
 .border {

--- a/static/sass/business-update.scss
+++ b/static/sass/business-update.scss
@@ -1,0 +1,30 @@
+@import '1-settings/all';
+@import '2-tools/all';
+@import '3-generic/all';
+@import '4-elements/all';
+@import '5-objects/all';
+@import '6-components/all';
+@import '7-overrides/all';
+
+// Page specific components
+// @todo - Combine `business-form__bucket` with `circle-form__bucket`
+.business-form {
+  &__bucket {
+    border-width: 3px;
+    border-color: $color-white-off;
+    border-style: solid;
+    padding: $size-s;
+    transition: border-color 0.2s;
+
+    &.selected {
+      border-color: $color-yellow-tribune;
+    }
+  }
+
+  &__bucket-header {
+    @extend %font-serif;
+    font-size: $size-l;
+    font-weight: bold;
+    line-height: 1;
+  }
+}

--- a/static/sass/circle-update.scss
+++ b/static/sass/circle-update.scss
@@ -1,0 +1,100 @@
+@import '1-settings/all';
+@import '2-tools/all';
+@import '3-generic/all';
+@import '4-elements/all';
+@import '5-objects/all';
+@import '6-components/all';
+@import '7-overrides/all';
+
+// Page specific components
+// @todo - Combine `circle-form__bucket` with `business-form__bucket`
+.circle-form {
+  &__bucket {
+    border-width: 3px;
+    border-color: $color-white-off;
+    border-style: solid;
+    padding: $size-s;
+    transition: border-color 0.2s;
+
+    &.selected {
+      border-color: $color-yellow-tribune;
+    }
+  }
+
+  &__bucket-header {
+    @extend %font-serif;
+    font-size: $size-l;
+    font-weight: bold;
+    line-height: 1;
+  }
+}
+
+.circle-wall {
+  &__logo {
+    margin: 0 $size-b $size-l;
+    text-align: center;
+
+    img {
+      max-width: 450px;
+      width: 100%;
+
+      @media print {
+        max-width: 175px;
+      }
+    }
+  }
+
+  &__heading {
+    @include mq($from: bp-s) {
+      text-align: center;
+    }
+
+    @media print {
+      font-size: $size-b;
+    }
+  }
+
+  &__list {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+
+    @include mq($from: bp-s) {
+      justify-content: center;
+    }
+
+    @media print {
+      display: initial;
+    }
+  }
+
+  &__item {
+    @extend %font-sansserif;
+    margin: 0 $size-xxs/2 $size-xxs/2 0;
+
+    @include mq($until: bp-s) {
+      flex: 1 1 100%;
+    }
+
+    @media print {
+      display: inline-block;
+      margin-bottom: 0;
+      margin-right: 0.15rem;
+    }
+  }
+
+  &__star {
+    color: $color-yellow-tribune;
+    font-size: $size-xs;
+  }
+
+  &__name {
+    @include mq($from: bp-s) {
+      font-size: $size-xs;
+    }
+
+    @media print {
+      font-size: 0.6rem;
+    }
+  }
+}

--- a/templates/business-form.html
+++ b/templates/business-form.html
@@ -31,7 +31,7 @@ Tribune{% endblock %} {% block og_meta %}
   organization's name and join a roster of community-minded businesses." %} {%
   include "includes/hero.html" %} {% endwith %}
 
-  <div class="opening-pitch section-padding">
+  <div class="grid_container grid_padded--xl section-padding">
     {% include 'includes/business_opening_pitch.html' %}
   </div>
 

--- a/templates/business-form.html
+++ b/templates/business-form.html
@@ -1,70 +1,62 @@
-{% extends "new_layout.html" %}
-
-{% block title %}Business Membership | The Texas Tribune{% endblock %}
-
-{% block og_meta %}
-  <meta property="og:url" content="https://support.texastribune.org/businessform">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}">
-  <meta property="og:title" content="Business Membership | The Texas Tribune">
-  <meta property="og:type" content="website">
-  <meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today.">
-{% endblock %}
-
-{% block stylesheets %}
-  {% for stylesheet in bundles['css'] %}
-    <link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
-  {% endfor %}
-{% endblock %}
-
-{% block head_scripts %}
-{% if form_data and message %}
+{% extends "new_layout.html" %} {% block title %}Business Membership | The Texas
+Tribune{% endblock %} {% block og_meta %}
+<meta
+  property="og:url"
+  content="https://support.texastribune.org/businessform"
+/>
+<meta
+  property="og:image"
+  content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}"
+/>
+<meta property="og:title" content="Business Membership | The Texas Tribune" />
+<meta property="og:type" content="website" />
+<meta
+  property="og:description"
+  content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today."
+/>
+{% endblock %} {% block stylesheets %} {% for stylesheet in bundles['css'] %}
+<link rel="stylesheet" type="text/css" href="{{ stylesheet }}" /> {% endfor %}
+{% endblock %} {% block head_scripts %} {% if form_data and message %}
 <script>
   window.location.replace('#join-today');
 </script>
-{% endif %}
-{% endblock %}
+{% endif %} {% endblock %} {% block content %}
+<main class="main">
+  <!-- where the router component attaches -->
+  <div id="app" style="display:none;"></div>
 
-{% block content %}
-  <main class="main">
-    <!-- where the router component attaches -->
-    <div id="app" style="display:none;"></div>
+  <!-- hero component -->
+  {% with helperClass="hero--business", title="Join Our Business Membership
+  Program", intro="Make an annual contribution to The Texas Tribune in your
+  organization's name and join a roster of community-minded businesses." %} {%
+  include "includes/hero.html" %} {% endwith %}
 
-    <header class="business-hero">
-      <div class="business-hero__inner grid_container--m grid_padded">
-        <h1 class="business-hero__title grid_separator">Join Our Business Membership Program</h1>
-          <p class="business-hero__intro grid_separator">Make an annual contribution to The Texas Tribune in your organization's name and join a roster of community-minded businesses.</p>
-      </div>
-    </header>
+  <div class="opening-pitch section-padding">
+    {% include 'includes/business_opening_pitch.html' %}
+  </div>
 
-    <div class="opening-pitch section-padding">
-        {% include 'includes/business_opening_pitch.html' %}
-     </div>
-
-    <!-- for hash links when a form is invalid -->
-    <div id="join-today"></div>
-    <div class="grid_container grid_padded--xl">
-
+  <!-- for hash links when a form is invalid -->
+  <div id="join-today"></div>
+  <div class="grid_container grid_padded--xl">
     <section class="business-form grid_separator--l">
-          <!-- where the form attaches -->
+      <!-- where the form attaches -->
       <div id="business-form"></div>
-     </section>
+    </section>
 
-     <section class="business-questions grid_separator--l">
-        {% include 'includes/business_questions.html' %}
-     </section>
+    <section class="business-questions grid_separator--l">
+      {% include 'includes/business_questions.html' %}
+    </section>
 
-      <section class="business-wall grid_separator--l">
-        <figure class="business-wall__logo grid_separator--l">
-          <!-- <img src="{{ url_for('static', filename='img/business-logo.png')}}" alt="Business Membership logo"> -->
-        </figure>
-        <!-- where the wall component attaches -->
-        <div id="business-wall"></div>
-      </section>
-    </div>
-  </main>
-{% endblock %}
-
-{% block bottom_script %}
+    <section class="business-wall grid_separator--l">
+      <figure class="business-wall__logo grid_separator--l">
+        <!-- <img src="{{ url_for('static', filename='img/business-logo.png')}}" alt="Business Membership logo"> -->
+      </figure>
+      <!-- where the wall component attaches -->
+      <div id="business-wall"></div>
+    </section>
+  </div>
+</main>
+{% endblock %} {% block bottom_script %}
 <script src="https://js.stripe.com/v3/"></script>
 
 {% if form_data and message %}
@@ -72,9 +64,6 @@
   window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
   window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data|tojson }};
 </script>
-{% endif %}
-
-{% for script in bundles['js'] %}
-  <script src="{{ script }}"></script>
-{% endfor %}
-{% endblock %}
+{% endif %} {% for script in bundles['js'] %}
+<script src="{{ script }}"></script>
+{% endfor %} {% endblock %}

--- a/templates/business-form.html
+++ b/templates/business-form.html
@@ -1,26 +1,30 @@
-{% extends "new_layout.html" %} {% block title %}Business Membership | The Texas
-Tribune{% endblock %} {% block og_meta %}
-<meta
-  property="og:url"
-  content="https://support.texastribune.org/businessform"
-/>
-<meta
-  property="og:image"
-  content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}"
-/>
-<meta property="og:title" content="Business Membership | The Texas Tribune" />
-<meta property="og:type" content="website" />
-<meta
-  property="og:description"
-  content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today."
-/>
-{% endblock %} {% block stylesheets %} {% for stylesheet in bundles['css'] %}
-<link rel="stylesheet" type="text/css" href="{{ stylesheet }}" /> {% endfor %}
-{% endblock %} {% block head_scripts %} {% if form_data and message %}
+{% extends "new_layout.html" %}
+
+{% block title %}Business Membership | The Texas Tribune{% endblock %}
+
+{% block og_meta %}
+<meta property="og:url" content="https://support.texastribune.org/businessform">
+<meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}">
+<meta property="og:title" content="Business Membership | The Texas Tribune">
+<meta property="og:type" content="website">
+<meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today.">
+{% endblock %}
+
+{% block stylesheets %}
+{% for stylesheet in bundles['css'] %}
+<link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
+{% endfor %}
+{% endblock %}
+
+{% block head_scripts %}
+{% if form_data and message %}
 <script>
   window.location.replace('#join-today');
 </script>
-{% endif %} {% endblock %} {% block content %}
+{% endif %}
+{% endblock %}
+
+{% block content %}
 <main class="main">
   <!-- where the router component attaches -->
   <div id="app" style="display:none;"></div>
@@ -38,6 +42,7 @@ Tribune{% endblock %} {% block og_meta %}
   <!-- for hash links when a form is invalid -->
   <div id="join-today"></div>
   <div class="grid_container grid_padded--xl">
+
     <section class="business-form grid_separator--l">
       <!-- where the form attaches -->
       <div id="business-form"></div>
@@ -56,14 +61,19 @@ Tribune{% endblock %} {% block og_meta %}
     </section>
   </div>
 </main>
-{% endblock %} {% block bottom_script %}
+{% endblock %}
+
+{% block bottom_script %}
 <script src="https://js.stripe.com/v3/"></script>
 
 {% if form_data and message %}
 <script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
-  window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data|tojson }};
+  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message | tojson }};
+  window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data | tojson }};
 </script>
-{% endif %} {% for script in bundles['js'] %}
+{% endif %}
+
+{% for script in bundles['js'] %}
 <script src="{{ script }}"></script>
-{% endfor %} {% endblock %}
+{% endfor %}
+{% endblock %}

--- a/templates/business-form.html
+++ b/templates/business-form.html
@@ -3,17 +3,17 @@
 {% block title %}Business Membership | The Texas Tribune{% endblock %}
 
 {% block og_meta %}
-<meta property="og:url" content="https://support.texastribune.org/businessform">
-<meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}">
-<meta property="og:title" content="Business Membership | The Texas Tribune">
-<meta property="og:type" content="website">
-<meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today.">
+  <meta property="og:url" content="https://support.texastribune.org/businessform">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/business-social.jpg') }}">
+  <meta property="og:title" content="Business Membership | The Texas Tribune">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Business Member today.">
 {% endblock %}
 
 {% block stylesheets %}
-{% for stylesheet in bundles['css'] %}
-<link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
-{% endfor %}
+  {% for stylesheet in bundles['css'] %}
+    <link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
+  {% endfor %}
 {% endblock %}
 
 {% block head_scripts %}
@@ -25,42 +25,43 @@
 {% endblock %}
 
 {% block content %}
-<main class="main">
-  <!-- where the router component attaches -->
-  <div id="app" style="display:none;"></div>
+  <main class="main">
+    <!-- where the router component attaches -->
+    <div id="app" style="display:none;"></div>
 
-  <!-- hero component -->
-  {% with helperClass="hero--business", title="Join Our Business Membership
-  Program", intro="Make an annual contribution to The Texas Tribune in your
-  organization's name and join a roster of community-minded businesses." %} {%
-  include "includes/hero.html" %} {% endwith %}
+    <!-- hero component -->
+    {% with helperClass="hero--business", title="Join Our Business Membership
+    Program", intro="Make an annual contribution to The Texas Tribune in your
+    organization's name and join a roster of community-minded businesses." %} {%
+    include "includes/hero.html" %} {% endwith %}
 
-  <div class="grid_container grid_padded--xl section-padding">
-    {% include 'includes/business_opening_pitch.html' %}
-  </div>
 
-  <!-- for hash links when a form is invalid -->
-  <div id="join-today"></div>
-  <div class="grid_container grid_padded--xl">
+    <div class="grid_container grid_padded--xl section-padding">
+        {% include 'includes/business_opening_pitch.html' %}
+     </div>
+
+    <!-- for hash links when a form is invalid -->
+    <div id="join-today"></div>
+    <div class="grid_container grid_padded--xl">
 
     <section class="business-form grid_separator--l">
-      <!-- where the form attaches -->
+          <!-- where the form attaches -->
       <div id="business-form"></div>
-    </section>
+     </section>
 
-    <section class="business-questions grid_separator--l">
-      {% include 'includes/business_questions.html' %}
-    </section>
+     <section class="business-questions grid_separator--l">
+        {% include 'includes/business_questions.html' %}
+     </section>
 
-    <section class="business-wall grid_separator--l">
-      <figure class="business-wall__logo grid_separator--l">
-        <!-- <img src="{{ url_for('static', filename='img/business-logo.png')}}" alt="Business Membership logo"> -->
-      </figure>
-      <!-- where the wall component attaches -->
-      <div id="business-wall"></div>
-    </section>
-  </div>
-</main>
+      <section class="business-wall grid_separator--l">
+        <figure class="business-wall__logo grid_separator--l">
+          <!-- <img src="{{ url_for('static', filename='img/business-logo.png')}}" alt="Business Membership logo"> -->
+        </figure>
+        <!-- where the wall component attaches -->
+        <div id="business-wall"></div>
+      </section>
+    </div>
+  </main>
 {% endblock %}
 
 {% block bottom_script %}
@@ -68,12 +69,12 @@
 
 {% if form_data and message %}
 <script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message | tojson }};
-  window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data | tojson }};
+  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
+  window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data|tojson }};
 </script>
 {% endif %}
 
 {% for script in bundles['js'] %}
-<script src="{{ script }}"></script>
+  <script src="{{ script }}"></script>
 {% endfor %}
 {% endblock %}

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -3,17 +3,17 @@
 {% block title %}Circle Membership | The Texas Tribune{% endblock %}
 
 {% block og_meta %}
-<meta property="og:url" content="https://support.texastribune.org/circleform">
-<meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}">
-<meta property="og:title" content="Circle Membership | The Texas Tribune">
-<meta property="og:type" content="website">
-<meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today.">
+  <meta property="og:url" content="https://support.texastribune.org/circleform">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}">
+  <meta property="og:title" content="Circle Membership | The Texas Tribune">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today.">
 {% endblock %}
 
 {% block stylesheets %}
-{% for stylesheet in bundles['css'] %}
-<link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
-{% endfor %}
+  {% for stylesheet in bundles['css'] %}
+    <link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
+  {% endfor %}
 {% endblock %}
 
 {% block head_scripts %}
@@ -25,115 +25,109 @@
 {% endblock %}
 
 {% block content %}
-<main class="main">
-  <!-- where the router component attaches -->
-  <div id="app" style="display:none;"></div>
+  <main class="main">
+    <!-- where the router component attaches -->
+    <div id="app" style="display:none;"></div>
 
-  <!-- hero component -->
-  {% with helperClass="hero--circle print__hide", title="Join Our Circle",
-  intro="The Texas Tribune is the only member-supported, digitally focused,
-  nonpartisan news organization that informs and engages with Texans about
-  public policy, politics, government and statewide issues.", cta="Our nonprofit
-  newsroom depends on your support!" %} {% include "includes/hero.html" %} {%
-  endwith %}
+    <!-- hero component -->
+    {% with helperClass="hero--circle print__hide", title="Join Our Circle",
+    intro="The Texas Tribune is the only member-supported, digitally focused,
+    nonpartisan news organization that informs and engages with Texans about
+    public policy, politics, government and statewide issues.", cta="Our nonprofit
+    newsroom depends on your support!" %} {% include "includes/hero.html" %} {%
+    endwith %}
 
-  <div class="grid_container grid_padded--xl">
-    <section class="section-padding print__hide">
-      <header class="circle-donate__header grid_container--m grid_separator">
-        <!-- IDs are for ARIA usage in the form -->
-        <div class="border--yellow_notch"></div>
-        <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">Your Circle Membership</h2>
-        <div id="circle-donate-intro" class="prose grid_separator--xl">
-          <p>Circle Membership is a three-year commitment to provide backing for the vital work of our journalists.</p>
-          <p>Circle Members believe in supporting our mission as a public service — free of charge on our website, in
-            free syndication and at our numerous free public events — so all Texans have access to nonpartisan news and
-            information.</p>
+    <div class="grid_container grid_padded--xl">
+      <section class="section-padding print__hide">
+        <header class="circle-donate__header grid_container--m grid_separator">
+          <!-- IDs are for ARIA usage in the form -->
+          <div class="border--yellow_notch"></div>
+          <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">Your Circle Membership</h2>
+          <div id="circle-donate-intro" class="prose grid_separator--xl">
+            <p>Circle Membership is a three-year commitment to provide backing for the vital work of our journalists.</p>
+            <p>Circle Members believe in supporting our mission as a public service — free of charge on our website, in free syndication and at our numerous free public events — so all Texans have access to nonpartisan news and information.</p>
+          </div>
+        </header>
+        <!-- for hash links when a form is invalid -->
+        <div id="join-today"></div>
+        <!-- where the form attaches -->
+        <div id="circle-form"></div>
+
+        <div class="prose grid_container--m">
+          <br>
+          <p>You can also <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}">donate by mail</a>.</p>
         </div>
-      </header>
-      <!-- for hash links when a form is invalid -->
-      <div id="join-today"></div>
-      <!-- where the form attaches -->
-      <div id="circle-form"></div>
+      </section>
 
-      <div class="prose grid_container--m">
-        <br>
-        <p>You can also <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}">donate by mail</a>.</p>
-      </div>
-    </section>
+      <section class="grid_container--m section-padding grid_padded print__hide">
+        <header>
+          <div class="border--yellow_notch"></div>
+          <h4 class="link--blue grid_separator">Circle members receive <a href="/donate">all membership benefits</a>, plus:</h4>
+        </header>
+        <h4 class="smallcaps--light"><strong>Exclusive Content</strong></h4>
+        <div class="prose grid_separator--xl"><p>Special notifications and updates from Evan Smith, CEO</p></div>
 
-    <section class="grid_container--m section-padding grid_padded print__hide">
-      <header>
-        <div class="border--yellow_notch"></div>
-        <h4 class="link--blue grid_separator">Circle members receive <a href="/donate">all membership benefits</a>,
-          plus:</h4>
-      </header>
-      <h4 class="smallcaps--light"><strong>Exclusive Content</strong></h4>
-      <div class="prose grid_separator--xl">
-        <p>Special notifications and updates from Evan Smith, CEO</p>
-      </div>
+        <h4 class="smallcaps--light"><strong>Access Benefits</strong></h4>
+        <ul class="list--bulleted grid_separator--l">
+          <li>Early registration to select Tribune events and VIP receptions</li>
+          <li>Invitations to exclusive events as part of The Texas Tribune Festival</li>
+          <li>Year-round reserved seating at Tribune statewide events</li>
+        </ul>
 
-      <h4 class="smallcaps--light"><strong>Access Benefits</strong></h4>
-      <ul class="list--bulleted grid_separator--l">
-        <li>Early registration to select Tribune events and VIP receptions</li>
-        <li>Invitations to exclusive events as part of The Texas Tribune Festival</li>
-        <li>Year-round reserved seating at Tribune statewide events</li>
-      </ul>
-
-      <h4 class="smallcaps--light"><strong>Special Recognition</strong></h4>
-      <div class="prose grid_separator--xl">
-        <p>Exclusive recognition as a Texas Tribune Circle Member on our site</p>
-      </div>
-    </section>
-
-    <section class="grid_container--m section-padding grid_padded print__hide">
-      <header>
-        <div class="border--yellow_notch"></div>
-        <h4 class="grid_separator circle-benefits__header">Questions?</h4>
-      </header>
-      <div class="contact grid_row grid_wrap--l grid_separator">
-        <div class="col">
-          <p class="grid_separator--s">For Circle Membership, contact:</p>
-          <p><strong>Jenny Ajluni</strong></p>
-          <p>Development Officer</p>
-          <p>515-250-9168</p>
-          <p class="grid_separator"><a href="mailto:jajluni@texastribune.org">jajluni@texastribune.org</a></p>
+        <h4 class="smallcaps--light"><strong>Special Recognition</strong></h4>
+        <div class="prose grid_separator--xl">
+          <p>Exclusive recognition as a Texas Tribune Circle Member on our site</p>
         </div>
-        <div class="col">
-          <p class="grid_separator--s">For major gifts or grants, contact:</p>
-          <p><strong>Terry Quinn</strong></p>
-          <p>Chief Development Officer</p>
-          <p>512-716-8613</p>
-          <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
-        </div>
-      </div>
-      <div class="contact grid_row grid_wrap--l grid_separator--l">
-        <div class="col">
-          <p class="grid_separator--s">For other membership questions, contact:</p>
-          <p><strong>Sarah Glen</strong></p>
-          <p>Loyalty Program Manager</p>
-          <p>512-716-8696</p>
-          <p class="grid_separator"><a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a></p>
-        </div>
-        <div class="col">
-          <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate
-              sponsorships</a> and business membership, contact:</p>
-          <p><strong>April Hinkle</strong></p>
-          <p>Chief Revenue Officer</p>
-          <p>512-716-8634</p>
-          <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
-        </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="circle-wall grid_separator--l">
-      <figure class="circle-wall__logo grid_separator--l">
-        <img src="{{ url_for('static', filename='img/circle-logo.png')}}" alt="Circle Membership logo">
-      </figure>
-      <!-- where the wall component attaches -->
-      <div id="circle-wall"></div>
-    </section>
-  </div>
-</main>
+      <section class="grid_container--m section-padding grid_padded print__hide">
+        <header>
+          <div class="border--yellow_notch"></div>
+          <h4 class="grid_separator circle-benefits__header">Questions?</h4>
+        </header>
+        <div class="contact grid_row grid_wrap--l grid_separator">
+          <div class="col">
+            <p class="grid_separator--s">For Circle Membership, contact:</p>
+            <p><strong>Jenny Ajluni</strong></p>
+            <p>Development Officer</p>
+            <p>515-250-9168</p>
+            <p class="grid_separator"><a href="mailto:jajluni@texastribune.org">jajluni@texastribune.org</a></p>
+          </div>
+          <div class="col">
+            <p class="grid_separator--s">For major gifts or grants, contact:</p>
+            <p><strong>Terry Quinn</strong></p>
+            <p>Chief Development Officer</p>
+            <p>512-716-8613</p>
+            <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
+          </div>
+        </div>
+        <div class="contact grid_row grid_wrap--l grid_separator--l">
+          <div class="col">
+            <p class="grid_separator--s">For other membership questions, contact:</p>
+            <p><strong>Sarah Glen</strong></p>
+            <p>Loyalty Program Manager</p>
+            <p>512-716-8696</p>
+            <p class="grid_separator"><a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a></p>
+          </div>
+          <div class="col">
+            <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate sponsorships</a> and business membership, contact:</p>
+            <p><strong>April Hinkle</strong></p>
+            <p>Chief Revenue Officer</p>
+            <p>512-716-8634</p>
+            <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="circle-wall grid_separator--l">
+        <figure class="circle-wall__logo grid_separator--l">
+          <img src="{{ url_for('static', filename='img/circle-logo.png')}}" alt="Circle Membership logo">
+        </figure>
+        <!-- where the wall component attaches -->
+        <div id="circle-wall"></div>
+      </section>
+    </div>
+  </main>
 {% endblock %}
 
 {% block bottom_script %}
@@ -141,12 +135,12 @@
 
 {% if form_data and message %}
 <script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message | tojson }};
-  window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data | tojson }};
+  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
+  window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data|tojson }};
 </script>
 {% endif %}
 
 {% for script in bundles['js'] %}
-<script src="{{ script }}"></script>
+  <script src="{{ script }}"></script>
 {% endfor %}
 {% endblock %}

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -1,136 +1,179 @@
-{% extends "new_layout.html" %}
-
-{% block title %}Circle Membership | The Texas Tribune{% endblock %}
-
-{% block og_meta %}
-  <meta property="og:url" content="https://support.texastribune.org/circleform">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}">
-  <meta property="og:title" content="Circle Membership | The Texas Tribune">
-  <meta property="og:type" content="website">
-  <meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today.">
-{% endblock %}
-
-{% block stylesheets %}
-  {% for stylesheet in bundles['css'] %}
-    <link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
-  {% endfor %}
-{% endblock %}
-
-{% block head_scripts %}
-{% if form_data and message %}
+{% extends "new_layout.html" %} {% block title %}Circle Membership | The Texas
+Tribune{% endblock %} {% block og_meta %}
+<meta property="og:url" content="https://support.texastribune.org/circleform" />
+<meta
+  property="og:image"
+  content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}"
+/>
+<meta property="og:title" content="Circle Membership | The Texas Tribune" />
+<meta property="og:type" content="website" />
+<meta
+  property="og:description"
+  content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today."
+/>
+{% endblock %} {% block stylesheets %} {% for stylesheet in bundles['css'] %}
+<link rel="stylesheet" type="text/css" href="{{ stylesheet }}" /> {% endfor %}
+{% endblock %} {% block head_scripts %} {% if form_data and message %}
 <script>
   window.location.replace('#join-today');
 </script>
-{% endif %}
-{% endblock %}
+{% endif %} {% endblock %} {% block content %}
+<main class="main">
+  <!-- where the router component attaches -->
+  <div id="app" style="display:none;"></div>
 
-{% block content %}
-  <main class="main">
-    <!-- where the router component attaches -->
-    <div id="app" style="display:none;"></div>
+  <!-- hero component -->
+  {% with helperClass="hero--circle print__hide", title="Join Our Circle",
+  intro="The Texas Tribune is the only member-supported, digitally focused,
+  nonpartisan news organization that informs and engages with Texans about
+  public policy, politics, government and statewide issues.", cta="Our nonprofit
+  newsroom depends on your support!" %} {% include "includes/hero.html" %} {%
+  endwith %}
 
-    <header class="circle-hero">
-      <div class="circle-hero__inner grid_container--m grid_padded">
-        <h1 class="circle-hero__title grid_separator">Join Our Circle</h1>
-        <p class="circle-hero__intro grid_separator">The Texas Tribune is the only member-supported, digitally focused, nonpartisan news organization that informs and engages with Texans about public policy, politics, government and statewide issues.</p>
-        <p class="circle-hero__cta">Our nonprofit newsroom depends on your support!</p>
+  <div class="grid_container grid_padded--xl">
+    <section class="circle-donate section-padding print__hide">
+      <header class="circle-donate__header grid_container--m grid_separator">
+        <!-- IDs are for ARIA usage in the form -->
+        <div class="border--yellow_notch"></div>
+        <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">
+          Your Circle Membership
+        </h2>
+        <div id="circle-donate-intro" class="prose grid_separator--xl">
+          <p>
+            Circle Membership is a three-year commitment to provide backing for
+            the vital work of our journalists.
+          </p>
+          <p>
+            Circle Members believe in supporting our mission as a public service
+            — free of charge on our website, in free syndication and at our
+            numerous free public events — so all Texans have access to
+            nonpartisan news and information.
+          </p>
+        </div>
+      </header>
+      <!-- for hash links when a form is invalid -->
+      <div id="join-today"></div>
+      <!-- where the form attaches -->
+      <div id="circle-form"></div>
+
+      <div class="prose grid_container--m">
+        <br />
+        <p>
+          You can also
+          <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}"
+            >donate by mail</a
+          >.
+        </p>
       </div>
-    </header>
+    </section>
 
-    <div class="grid_container grid_padded--xl">
-      <section class="circle-donate section-padding">
-        <header class="circle-donate__header grid_container--m grid_separator">
-          <!-- IDs are for ARIA usage in the form -->
-          <div class="border--yellow_notch"></div>
-          <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">Your Circle Membership</h2>
-          <div id="circle-donate-intro" class="prose grid_separator--xl">
-            <p>Circle Membership is a three-year commitment to provide backing for the vital work of our journalists.</p>
-            <p>Circle Members believe in supporting our mission as a public service — free of charge on our website, in free syndication and at our numerous free public events — so all Texans have access to nonpartisan news and information.</p>
-          </div>
-        </header>
-        <!-- for hash links when a form is invalid -->
-        <div id="join-today"></div>
-        <!-- where the form attaches -->
-        <div id="circle-form"></div>
+    <section
+      class="grid_container--m circle-benefits section-padding grid_padded print__hide"
+    >
+      <header>
+        <div class="border--yellow_notch"></div>
+        <h4 class="link--blue grid_separator">
+          Circle members receive <a href="/donate">all membership benefits</a>,
+          plus:
+        </h4>
+      </header>
+      <h4 class="smallcaps--light"><strong>Exclusive Content</strong></h4>
+      <div class="prose grid_separator--xl">
+        <p>Special notifications and updates from Evan Smith, CEO</p>
+      </div>
 
-        <div class="prose grid_container--m">
-          <br>
-          <p>You can also <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}">donate by mail</a>.</p>
+      <h4 class="smallcaps--light"><strong>Access Benefits</strong></h4>
+      <ul class="list--bulleted grid_separator--l">
+        <li>Early registration to select Tribune events and VIP receptions</li>
+        <li>
+          Invitations to exclusive events as part of The Texas Tribune Festival
+        </li>
+        <li>Year-round reserved seating at Tribune statewide events</li>
+      </ul>
+
+      <h4 class="smallcaps--light"><strong>Special Recognition</strong></h4>
+      <div class="prose grid_separator--xl">
+        <p>
+          Exclusive recognition as a Texas Tribune Circle Member on our site
+        </p>
+      </div>
+    </section>
+
+    <section
+      class="grid_container--m circle-benefits section-padding grid_padded print__hide"
+    >
+      <header>
+        <div class="border--yellow_notch"></div>
+        <h4 class="grid_separator circle-benefits__header">Questions?</h4>
+      </header>
+      <div class="contact grid_row grid_wrap--l grid_separator">
+        <div class="col">
+          <p class="grid_separator--s">For Circle Membership, contact:</p>
+          <p><strong>Jenny Ajluni</strong></p>
+          <p>Development Officer</p>
+          <p>515-250-9168</p>
+          <p class="grid_separator">
+            <a href="mailto:jajluni@texastribune.org"
+              >jajluni@texastribune.org</a
+            >
+          </p>
         </div>
-      </section>
-
-      <section class="grid_container--m circle-benefits section-padding grid_padded">
-        <header>
-          <div class="border--yellow_notch"></div>
-          <h4 class="link--blue grid_separator">Circle members receive <a href="/donate">all membership benefits</a>, plus:</h4>
-        </header>
-        <h4 class="smallcaps--light"><strong>Exclusive Content</strong></h4>
-        <div class="prose grid_separator--xl"><p>Special notifications and updates from Evan Smith, CEO</p></div>
-
-        <h4 class="smallcaps--light"><strong>Access Benefits</strong></h4>
-        <ul class="list--bulleted grid_separator--l">
-          <li>Early registration to select Tribune events and VIP receptions</li>
-          <li>Invitations to exclusive events as part of The Texas Tribune Festival</li>
-          <li>Year-round reserved seating at Tribune statewide events</li>
-        </ul>
-
-        <h4 class="smallcaps--light"><strong>Special Recognition</strong></h4>
-        <div class="prose grid_separator--xl">
-          <p>Exclusive recognition as a Texas Tribune Circle Member on our site</p>
+        <div class="col">
+          <p class="grid_separator--s">For major gifts or grants, contact:</p>
+          <p><strong>Terry Quinn</strong></p>
+          <p>Chief Development Officer</p>
+          <p>512-716-8613</p>
+          <p class="grid_separator">
+            <a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a>
+          </p>
         </div>
-      </section>
-
-      <section class="grid_container--m circle-benefits section-padding grid_padded">
-        <header>
-          <div class="border--yellow_notch"></div>
-          <h4 class="grid_separator circle-benefits__header">Questions?</h4>
-        </header>
-        <div class="contact grid_row grid_wrap--l grid_separator">
-          <div class="col">
-            <p class="grid_separator--s">For Circle Membership, contact:</p>
-            <p><strong>Jenny Ajluni</strong></p>
-            <p>Development Officer</p>
-            <p>515-250-9168</p>
-            <p class="grid_separator"><a href="mailto:jajluni@texastribune.org">jajluni@texastribune.org</a></p>
-          </div>
-          <div class="col">
-            <p class="grid_separator--s">For major gifts or grants, contact:</p>
-            <p><strong>Terry Quinn</strong></p>
-            <p>Chief Development Officer</p>
-            <p>512-716-8613</p>
-            <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
-          </div>
+      </div>
+      <div class="contact grid_row grid_wrap--l grid_separator--l">
+        <div class="col">
+          <p class="grid_separator--s">
+            For other membership questions, contact:
+          </p>
+          <p><strong>Sarah Glen</strong></p>
+          <p>Loyalty Program Manager</p>
+          <p>512-716-8696</p>
+          <p class="grid_separator">
+            <a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a>
+          </p>
         </div>
-        <div class="contact grid_row grid_wrap--l grid_separator--l">
-          <div class="col">
-            <p class="grid_separator--s">For other membership questions, contact:</p>
-            <p><strong>Sarah Glen</strong></p>
-            <p>Loyalty Program Manager</p>
-            <p>512-716-8696</p>
-            <p class="grid_separator"><a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a></p>
-          </div>
-          <div class="col">
-            <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate sponsorships</a> and business membership, contact:</p>
-            <p><strong>April Hinkle</strong></p>
-            <p>Chief Revenue Officer</p>
-            <p>512-716-8634</p>
-            <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
-          </div>
+        <div class="col">
+          <p class="grid_separator--s">
+            For
+            <a
+              href="https://www.texastribune.org/support-us/corporate-sponsors/"
+              >corporate sponsorships</a
+            >
+            and business membership, contact:
+          </p>
+          <p><strong>April Hinkle</strong></p>
+          <p>Chief Revenue Officer</p>
+          <p>512-716-8634</p>
+          <p>
+            <a href="mailto:ahinkle@texastribune.org"
+              >ahinkle@texastribune.org</a
+            >
+          </p>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <section class="circle-wall grid_separator--l">
-        <figure class="circle-wall__logo grid_separator--l">
-          <img src="{{ url_for('static', filename='img/circle-logo.png')}}" alt="Circle Membership logo">
-        </figure>
-        <!-- where the wall component attaches -->
-        <div id="circle-wall"></div>
-      </section>
-    </div>
-  </main>
-{% endblock %}
-
-{% block bottom_script %}
+    <section class="circle-wall grid_separator--l">
+      <figure class="circle-wall__logo grid_separator--l">
+        <img
+          src="{{ url_for('static', filename='img/circle-logo.png')}}"
+          alt="Circle Membership logo"
+        />
+      </figure>
+      <!-- where the wall component attaches -->
+      <div id="circle-wall"></div>
+    </section>
+  </div>
+</main>
+{% endblock %} {% block bottom_script %}
 <script src="https://js.stripe.com/v3/"></script>
 
 {% if form_data and message %}
@@ -138,9 +181,6 @@
   window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
   window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data|tojson }};
 </script>
-{% endif %}
-
-{% for script in bundles['js'] %}
-  <script src="{{ script }}"></script>
-{% endfor %}
-{% endblock %}
+{% endif %} {% for script in bundles['js'] %}
+<script src="{{ script }}"></script>
+{% endfor %} {% endblock %}

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -1,23 +1,30 @@
-{% extends "new_layout.html" %} {% block title %}Circle Membership | The Texas
-Tribune{% endblock %} {% block og_meta %}
-<meta property="og:url" content="https://support.texastribune.org/circleform" />
-<meta
-  property="og:image"
-  content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}"
-/>
-<meta property="og:title" content="Circle Membership | The Texas Tribune" />
-<meta property="og:type" content="website" />
-<meta
-  property="og:description"
-  content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today."
-/>
-{% endblock %} {% block stylesheets %} {% for stylesheet in bundles['css'] %}
-<link rel="stylesheet" type="text/css" href="{{ stylesheet }}" /> {% endfor %}
-{% endblock %} {% block head_scripts %} {% if form_data and message %}
+{% extends "new_layout.html" %}
+
+{% block title %}Circle Membership | The Texas Tribune{% endblock %}
+
+{% block og_meta %}
+<meta property="og:url" content="https://support.texastribune.org/circleform">
+<meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/circle-social.jpg') }}">
+<meta property="og:title" content="Circle Membership | The Texas Tribune">
+<meta property="og:type" content="website">
+<meta property="og:description" content="At The Texas Tribune, members make all the difference. Join me in supporting the Tribune’s nonprofit newsroom by becoming a Circle Member today.">
+{% endblock %}
+
+{% block stylesheets %}
+{% for stylesheet in bundles['css'] %}
+<link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
+{% endfor %}
+{% endblock %}
+
+{% block head_scripts %}
+{% if form_data and message %}
 <script>
   window.location.replace('#join-today');
 </script>
-{% endif %} {% endblock %} {% block content %}
+{% endif %}
+{% endblock %}
+
+{% block content %}
 <main class="main">
   <!-- where the router component attaches -->
   <div id="app" style="display:none;"></div>
@@ -31,24 +38,16 @@ Tribune{% endblock %} {% block og_meta %}
   endwith %}
 
   <div class="grid_container grid_padded--xl">
-    <section class="circle-donate section-padding print__hide">
+    <section class="section-padding print__hide">
       <header class="circle-donate__header grid_container--m grid_separator">
         <!-- IDs are for ARIA usage in the form -->
         <div class="border--yellow_notch"></div>
-        <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">
-          Your Circle Membership
-        </h2>
+        <h2 id="circle-donate-hed" class="circle-donate__hed grid_separator">Your Circle Membership</h2>
         <div id="circle-donate-intro" class="prose grid_separator--xl">
-          <p>
-            Circle Membership is a three-year commitment to provide backing for
-            the vital work of our journalists.
-          </p>
-          <p>
-            Circle Members believe in supporting our mission as a public service
-            — free of charge on our website, in free syndication and at our
-            numerous free public events — so all Texans have access to
-            nonpartisan news and information.
-          </p>
+          <p>Circle Membership is a three-year commitment to provide backing for the vital work of our journalists.</p>
+          <p>Circle Members believe in supporting our mission as a public service — free of charge on our website, in
+            free syndication and at our numerous free public events — so all Texans have access to nonpartisan news and
+            information.</p>
         </div>
       </header>
       <!-- for hash links when a form is invalid -->
@@ -57,25 +56,16 @@ Tribune{% endblock %} {% block og_meta %}
       <div id="circle-form"></div>
 
       <div class="prose grid_container--m">
-        <br />
-        <p>
-          You can also
-          <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}"
-            >donate by mail</a
-          >.
-        </p>
+        <br>
+        <p>You can also <a href="{{ url_for('static', filename='pdf/circle-donate.pdf') }}">donate by mail</a>.</p>
       </div>
     </section>
 
-    <section
-      class="grid_container--m circle-benefits section-padding grid_padded print__hide"
-    >
+    <section class="grid_container--m section-padding grid_padded print__hide">
       <header>
         <div class="border--yellow_notch"></div>
-        <h4 class="link--blue grid_separator">
-          Circle members receive <a href="/donate">all membership benefits</a>,
-          plus:
-        </h4>
+        <h4 class="link--blue grid_separator">Circle members receive <a href="/donate">all membership benefits</a>,
+          plus:</h4>
       </header>
       <h4 class="smallcaps--light"><strong>Exclusive Content</strong></h4>
       <div class="prose grid_separator--xl">
@@ -85,23 +75,17 @@ Tribune{% endblock %} {% block og_meta %}
       <h4 class="smallcaps--light"><strong>Access Benefits</strong></h4>
       <ul class="list--bulleted grid_separator--l">
         <li>Early registration to select Tribune events and VIP receptions</li>
-        <li>
-          Invitations to exclusive events as part of The Texas Tribune Festival
-        </li>
+        <li>Invitations to exclusive events as part of The Texas Tribune Festival</li>
         <li>Year-round reserved seating at Tribune statewide events</li>
       </ul>
 
       <h4 class="smallcaps--light"><strong>Special Recognition</strong></h4>
       <div class="prose grid_separator--xl">
-        <p>
-          Exclusive recognition as a Texas Tribune Circle Member on our site
-        </p>
+        <p>Exclusive recognition as a Texas Tribune Circle Member on our site</p>
       </div>
     </section>
 
-    <section
-      class="grid_container--m circle-benefits section-padding grid_padded print__hide"
-    >
+    <section class="grid_container--m section-padding grid_padded print__hide">
       <header>
         <div class="border--yellow_notch"></div>
         <h4 class="grid_separator circle-benefits__header">Questions?</h4>
@@ -112,75 +96,57 @@ Tribune{% endblock %} {% block og_meta %}
           <p><strong>Jenny Ajluni</strong></p>
           <p>Development Officer</p>
           <p>515-250-9168</p>
-          <p class="grid_separator">
-            <a href="mailto:jajluni@texastribune.org"
-              >jajluni@texastribune.org</a
-            >
-          </p>
+          <p class="grid_separator"><a href="mailto:jajluni@texastribune.org">jajluni@texastribune.org</a></p>
         </div>
         <div class="col">
           <p class="grid_separator--s">For major gifts or grants, contact:</p>
           <p><strong>Terry Quinn</strong></p>
           <p>Chief Development Officer</p>
           <p>512-716-8613</p>
-          <p class="grid_separator">
-            <a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a>
-          </p>
+          <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
         </div>
       </div>
       <div class="contact grid_row grid_wrap--l grid_separator--l">
         <div class="col">
-          <p class="grid_separator--s">
-            For other membership questions, contact:
-          </p>
+          <p class="grid_separator--s">For other membership questions, contact:</p>
           <p><strong>Sarah Glen</strong></p>
           <p>Loyalty Program Manager</p>
           <p>512-716-8696</p>
-          <p class="grid_separator">
-            <a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a>
-          </p>
+          <p class="grid_separator"><a href="mailto:sglen@texastribune.org">sglen@texastribune.org</a></p>
         </div>
         <div class="col">
-          <p class="grid_separator--s">
-            For
-            <a
-              href="https://www.texastribune.org/support-us/corporate-sponsors/"
-              >corporate sponsorships</a
-            >
-            and business membership, contact:
-          </p>
+          <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate
+              sponsorships</a> and business membership, contact:</p>
           <p><strong>April Hinkle</strong></p>
           <p>Chief Revenue Officer</p>
           <p>512-716-8634</p>
-          <p>
-            <a href="mailto:ahinkle@texastribune.org"
-              >ahinkle@texastribune.org</a
-            >
-          </p>
+          <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
         </div>
       </div>
     </section>
 
     <section class="circle-wall grid_separator--l">
       <figure class="circle-wall__logo grid_separator--l">
-        <img
-          src="{{ url_for('static', filename='img/circle-logo.png')}}"
-          alt="Circle Membership logo"
-        />
+        <img src="{{ url_for('static', filename='img/circle-logo.png')}}" alt="Circle Membership logo">
       </figure>
       <!-- where the wall component attaches -->
       <div id="circle-wall"></div>
     </section>
   </div>
 </main>
-{% endblock %} {% block bottom_script %}
+{% endblock %}
+
+{% block bottom_script %}
 <script src="https://js.stripe.com/v3/"></script>
 
 {% if form_data and message %}
 <script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
-  window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data|tojson }};
+  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message | tojson }};
+  window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data | tojson }};
 </script>
-{% endif %} {% for script in bundles['js'] %}
+{% endif %}
+
+{% for script in bundles['js'] %}
 <script src="{{ script }}"></script>
-{% endfor %} {% endblock %}
+{% endfor %}
+{% endblock %}

--- a/templates/includes/business_questions.html
+++ b/templates/includes/business_questions.html
@@ -1,38 +1,52 @@
-<section class="grid_container--m business-benefits grid_padded">
-
-    <div class="prose grid_separator--xl">
-      <p>You can also <a
-      href="{{ url_for('static', filename='pdf/TT-BusinessMembership-contribution-form.pdf') }}">donate by mail</a>.</p>
-    </div>
-
-    <header>
-      <div class="border--yellow_notch"></div>
-      <h4 class="grid_separator">Questions?</h4>
-    </header>
-    <div class="business-contact grid_row grid_wrap--l grid_separator">
+<section class="grid_container--m grid_padded">
+  <div class="prose grid_separator--xl">
+    <p>
+      You can also
+      <a
+        href="{{ url_for('static', filename='pdf/TT-BusinessMembership-contribution-form.pdf') }}"
+        >donate by mail</a
+      >.
+    </p>
+  </div>
+  <header>
+    <div class="border--yellow_notch"></div>
+    <h4 class="grid_separator">Questions?</h4>
+  </header>
+  <div class="contact contact--small grid_row grid_wrap--l grid_separator">
     <div class="col">
-        <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate
-          sponsorships</a> and business membership, contact:</p>
-        <p><strong>April Hinkle</strong></p>
-        <p>Chief Revenue Officer</p>
-        <p>512-716-8634</p>
-        <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
-      </div>
-      <div class="col">
-        <p class="grid_separator--s">For major gifts or grants, contact:</p>
-        <p><strong>Terry Quinn</strong></p>
-        <p>Chief Development Officer</p>
-        <p>512-716-8613</p>
-        <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
-      </div>
+      <p class="grid_separator--s">
+        For
+        <a href="https://www.texastribune.org/support-us/corporate-sponsors/"
+          >corporate sponsorships</a
+        >
+        and business membership, contact:
+      </p>
+      <p><strong>April Hinkle</strong></p>
+      <p>Chief Revenue Officer</p>
+      <p>512-716-8634</p>
+      <p>
+        <a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a>
+      </p>
     </div>
-    <div class="business-contact grid_row grid_wrap--l grid_separator--l">
-      <div class="col">
-        <p class="grid_separator--s">For other membership questions, contact:</p>
-        <p><strong>Hamzah Khan</strong></p>
-        <p>Member Relations</p>
-        <p>512-716-8695</p>
-        <p class="grid_separator"><a href="mailto:hkhan@texastribune.org">hkhan@texastribune.org</a></p>
-      </div>
+    <div class="col">
+      <p class="grid_separator--s">For major gifts or grants, contact:</p>
+      <p><strong>Terry Quinn</strong></p>
+      <p>Chief Development Officer</p>
+      <p>512-716-8613</p>
+      <p class="grid_separator">
+        <a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a>
+      </p>
     </div>
+  </div>
+  <div class="contact contact--small grid_row grid_wrap--l grid_separator--l">
+    <div class="col">
+      <p class="grid_separator--s">For other membership questions, contact:</p>
+      <p><strong>Hamzah Khan</strong></p>
+      <p>Member Relations</p>
+      <p>512-716-8695</p>
+      <p class="grid_separator">
+        <a href="mailto:hkhan@texastribune.org">hkhan@texastribune.org</a>
+      </p>
+    </div>
+  </div>
 </section>

--- a/templates/includes/business_questions.html
+++ b/templates/includes/business_questions.html
@@ -1,52 +1,38 @@
-<section class="grid_container--m grid_padded">
-  <div class="prose grid_separator--xl">
-    <p>
-      You can also
-      <a
-        href="{{ url_for('static', filename='pdf/TT-BusinessMembership-contribution-form.pdf') }}"
-        >donate by mail</a
-      >.
-    </p>
-  </div>
-  <header>
-    <div class="border--yellow_notch"></div>
-    <h4 class="grid_separator">Questions?</h4>
-  </header>
-  <div class="contact contact--small grid_row grid_wrap--l grid_separator">
-    <div class="col">
-      <p class="grid_separator--s">
-        For
-        <a href="https://www.texastribune.org/support-us/corporate-sponsors/"
-          >corporate sponsorships</a
-        >
-        and business membership, contact:
-      </p>
-      <p><strong>April Hinkle</strong></p>
-      <p>Chief Revenue Officer</p>
-      <p>512-716-8634</p>
-      <p>
-        <a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a>
-      </p>
+<section class="grid_container--m business-benefits grid_padded">
+
+    <div class="prose grid_separator--xl">
+      <p>You can also <a
+      href="{{ url_for('static', filename='pdf/TT-BusinessMembership-contribution-form.pdf') }}">donate by mail</a>.</p>
     </div>
+
+    <header>
+      <div class="border--yellow_notch"></div>
+      <h4 class="grid_separator">Questions?</h4>
+    </header>
+    <div class="contact contact--small grid_row grid_wrap--l grid_separator">
     <div class="col">
-      <p class="grid_separator--s">For major gifts or grants, contact:</p>
-      <p><strong>Terry Quinn</strong></p>
-      <p>Chief Development Officer</p>
-      <p>512-716-8613</p>
-      <p class="grid_separator">
-        <a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a>
-      </p>
+        <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate
+          sponsorships</a> and business membership, contact:</p>
+        <p><strong>April Hinkle</strong></p>
+        <p>Chief Revenue Officer</p>
+        <p>512-716-8634</p>
+        <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
+      </div>
+      <div class="col">
+        <p class="grid_separator--s">For major gifts or grants, contact:</p>
+        <p><strong>Terry Quinn</strong></p>
+        <p>Chief Development Officer</p>
+        <p>512-716-8613</p>
+        <p class="grid_separator"><a href="mailto:tquinn@texastribune.org">tquinn@texastribune.org</a></p>
+      </div>
     </div>
-  </div>
-  <div class="contact contact--small grid_row grid_wrap--l grid_separator--l">
-    <div class="col">
-      <p class="grid_separator--s">For other membership questions, contact:</p>
-      <p><strong>Hamzah Khan</strong></p>
-      <p>Member Relations</p>
-      <p>512-716-8695</p>
-      <p class="grid_separator">
-        <a href="mailto:hkhan@texastribune.org">hkhan@texastribune.org</a>
-      </p>
+    <div class="contact contact--small grid_row grid_wrap--l grid_separator--l">
+      <div class="col">
+        <p class="grid_separator--s">For other membership questions, contact:</p>
+        <p><strong>Hamzah Khan</strong></p>
+        <p>Member Relations</p>
+        <p>512-716-8695</p>
+        <p class="grid_separator"><a href="mailto:hkhan@texastribune.org">hkhan@texastribune.org</a></p>
+      </div>
     </div>
-  </div>
 </section>

--- a/templates/includes/hero.html
+++ b/templates/includes/hero.html
@@ -1,0 +1,10 @@
+<header class="hero {{ helperClass|default('hero--default') }}">
+  <div class="hero__inner grid_container--m grid_padded">
+    <h1 class="hero__title grid_separator">{{ title|default('Welcome') }}</h1>
+    {% if intro %}
+    <p class="hero__intro grid_separator">{{ intro }}</p>
+    {% endif %} {% if cta %}
+    <p class="hero__cta">{{ cta }}</p>
+    {% endif %}
+  </div>
+</header>


### PR DESCRIPTION
#### What's this PR do?

This is the first iteration of a CSS refactor of this app. Don't be alarmed by the additions count. It's mostly copy and pastes of our old styles into different folders with the intention of deleting the old folders and root files

The new SCSS file directory will look like this:

    .sass
    ├── settings/       # variables
    ├── tools/          # mixins and functions
    ├── generic/        # resets
    ├── elements/       # html tags
    ├── objects/        # classed styles
    ├── components/     # UI custom styles
    ├── overrides/      # helpers and trumps
    ├── circle-update.scss
    └── business-update.scss
     


Along with the above reformatting, this also...

- Removes `business-wall__...` classes (don't seem to be used anywhere)
- Removes `.opening-pitch__intro` (unused)
- Removes `.business-benefits__...` (unused)
- Changes `@extend .class` to `@extend %class` (silent classes reduce output)
- Removes print media queries in favor of print utility class on `/circle`
- Removes `.business-hero` and `circle-hero` and creates new global `.hero` component
- Removes `.business-contact` and creates global `.contact` component
- Removes superfluous element resets on biz/circle pages
- Removes `.circle-donate__intro` (unused)

##### Reference: 
- [ITCSS: Scalable and Maintainable CSS Architecture](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/)
- [How to Organize your Styles with ITCSS](https://blog.codeminer42.com/how-to-organize-your-styles-with-itcss-3787cbc6dcbf)

#### Why are we doing this? How does it help us?

- Reduces file size of business and circle page CSS
- Hopefully increases maintainability of future CSS iterations

#### How should this be manually tested?

These should only affect `http://local.texastribune.org/circle` and `http://local.texastribune.org/business`. Hit those links in your local env and check their respective live pages.

#### How should this change be communicated to end users?

These updates are invisible to end users.

#### Are there any smells or added technical debt to note?

I made an assumption that the success/error UI would be intact. @AndrewGibson27, when you give this a look over let me know if there's an easy way to test that screen.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todolists/1443024867
https://3.basecamp.com/3098728/buckets/736178/todos/1516990374

#### Have you done the following, if applicable:

**_(optional: add explanation between parentheses)_**

- [ ] Added automated tests? _( N/A)_
- [x] Tested manually on mobile? _(Working on getting this deployed to [staging](https://donations-testing.texastribune.org/donate) to do that natively )_
- [x] Checked for performance implications? _(Slightly smaller file size)_
- [ ] Checked for security implications? _( N/A)_
- [ ] Updated the documentation/wiki? _( Added as a todo once everything is intact)_

#### TODOs / next steps:

- [x] _Get business and circle on the same CSS base (remove dup CSS)_
- [ ] _Turn one-off page styles into reusable components_
- [ ] _Integrate blastform (/blastform) into new structure - create components where needed_
- [ ] _Integrate homepage (/donate) into new structure - create components where needed_
- [ ] _Look into new grid helpers_
- [ ] _Delete legacy CSS_
- [ ] _Document new structure and methodology_
