### PR TITLE
Strip whitespace before Flask form validation

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -10,7 +10,19 @@ from wtforms.fields import (
 from wtforms.fields.html5 import EmailField
 
 
+def strip_filter(value):
+    if value is not None and hasattr(value, "strip"):
+        return value.strip()
+    return value
+
+
 class BaseForm(FlaskForm):
+    class Meta:
+        def bind_field(self, form, unbound_field, options):
+            filters = unbound_field.kwargs.get("filters", [])
+            filters.append(strip_filter)
+            return unbound_field.bind(form=form, filters=filters, **options)
+
     first_name = StringField(
         u"First name", [validators.required(message="Your first name is required.")]
     )


### PR DESCRIPTION
#### What's this PR do?
What the title says.

#### Why are we doing this? How does it help us?
So errant white spaces don't cause form invalidation.

#### How should this be manually tested?
+ `make` then `make restart`
+ On `/donate`, fill out the form with a reason length of 255 characters plus one trailing whitespace and a zip of 5 characters with one leading white space. Ensure you can submit it and that you get the "thank you page."
+ On `/business`, fill out the form with a city length of 40 characters plus one trailing or leading whitespace. Ensure you submit successfully.

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
@x110dc I got this solution from Stack Overflow. If it looks questionable from a Python perspective, let me know. I didn't add it to the Blast forms because it doesn't look like there is any length-based validation there and didn't want to risk breakage for no reason.

#### What are the relevant tickets?
Off-sprint.

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [ ] Tested manually on mobile? *(NA)*
* [ ] Checked for performance implications? *(NA)*
* [ ] Checked for security implications? *(NA)*
* [ ] Updated the documentation/wiki? *(NA)*