### PR TITLE
Add browser message to iOS

### DIFF
--- a/templates/includes/browser_bug.html
+++ b/templates/includes/browser_bug.html
@@ -3,7 +3,7 @@
 var isSafari = window.ApplePaySession;
 var uaString = navigator.userAgent;
 var isVersion = false;
-if (uaString.indexOf("Version/12.1 Safari") > -1 || uaString.indexOf("Version/12.2 Safari") > -1) {
+if (uaString.indexOf("Version/12.1") > -1 || uaString.indexOf("Version/12.2") > -1) {
   isVersion = true;
 }
 if(isSafari && isVersion) {


### PR DESCRIPTION
#### What's this PR do?
The userAgent for iOS doesn't include safari apparently so this will account for that.

#### Why are we doing this? How does it help us?
Show incompatible browser message on iOS

#### How should this be manually tested?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
