### PR TITLE
Blast charge page: push custom event to data layer

### DIFF
--- a/app.py
+++ b/app.py
@@ -473,7 +473,8 @@ def submit_blast_promo():
     if form.validate():
         app.logger.info("----Adding Blast subscription...")
         add_blast_subscription.delay(customer=customer, form=clean(request.form))
-        return render_template("blast-charge.html", bundles=bundles)
+        gtm = {"event_value": "200", "event_label": "annual discounted"}
+        return render_template("blast-charge.html", bundles=bundles, gtm=gtm)
     else:
         app.logger.error("Failed to validate form")
         message = "There was an issue saving your donation information."
@@ -513,6 +514,7 @@ def submit_blast():
     form = BlastForm(request.form)
 
     email_is_valid = validate_email(request.form["stripeEmail"])
+    amount = request.form["amount"]
 
     if email_is_valid:
         customer = stripe.Customer.create(
@@ -525,7 +527,17 @@ def submit_blast():
     if form.validate():
         app.logger.info("----Adding Blast subscription...")
         add_blast_subscription.delay(customer=customer, form=clean(request.form))
-        return render_template("blast-charge.html", bundles=bundles)
+
+        if amount == "349":
+            event_label = "annual"
+        elif amount == "40":
+            event_label = "monthly"
+        elif amount == "325":
+            event_label = "annual tax exempt"
+
+        gtm = {"event_value": amount, "event_label": event_label}
+
+        return render_template("blast-charge.html", bundles=bundles, gtm=gtm)
     else:
         app.logger.error("Failed to validate form")
         message = "There was an issue saving your donation information."

--- a/templates/blast-charge.html
+++ b/templates/blast-charge.html
@@ -55,7 +55,8 @@
     window.dataLayer.push({
       event: 'customBlastSuccess',
       gaAction: 'submit payment',
-      gaLabel: '' // installment: annual, monthly, annual tax exempt
+      gaLabel: '{{ gtm.event_label }}',
+      gaValue: '{{ gtm.event_value }}'
     });
   </script>
 {% endblock %}

--- a/templates/blast-charge.html
+++ b/templates/blast-charge.html
@@ -49,3 +49,13 @@
   </div>
 </div>
 {% endblock %}
+
+{% block bottom_script %}
+  <script>
+    window.dataLayer.push({
+      event: 'customBlastSuccess',
+      gaAction: 'submit payment',
+      gaLabel: '' // installment: annual, monthly, annual tax exempt
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
#### What's this PR do?
Triggers a GTM custom event when a subscriber hits the blast charge page.

#### Why are we doing this? How does it help us?
To track successful blast sign-ups. This tracking broke during the synced deploy.

#### How should this be manually tested?
- Turn on GTM's preview mode 
- Navigate to support.texastribune.org/blastform
- Fill out the form, using a test Stripe card https://stripe.com/docs/testing
- When you land on the charge page, look for the event "GA - Event - Blast - Master" in the GTM console. 

#### How should this change be communicated to end users?
Amanda requested this. I'll update her. 

#### Are there any smells or added technical debt to note?
I'm not sure what this is doing. Is this a remnant of old GA tracking? (This is in blast-charge.html)

```
{% block adwords_conversion_code %}
<!-- Event snippet for The Blast purchases conversion page -->
<script>
  gtag('event', 'conversion', {
      'send_to': 'AW-1018212315/4d93CMfBwnkQ29_C5QM',
      'transaction_id': ''
  });
</script>
{% endblock %}
```

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/1029921/todos/1637305111

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *Populate the event label with the installment (monthly, annual, annual tax exempt)*
