### PR TITLE
Removed FB pixel + FB conversion tracking

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,42 +46,6 @@
 
 {% block adwords_conversion_code %}{% endblock %}
 
-  <script>
-    (function() {
-      var _fbq = window._fbq || (window._fbq = []);
-      if (!_fbq.loaded) {
-        var fbds = document.createElement('script');
-        fbds.async = true;
-        fbds.src = '//connect.facebook.net/en_US/fbds.js';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(fbds, s);
-        _fbq.loaded = true;
-      }
-    })();
-    window._fbq = window._fbq || [];
-    window._fbq.push(['track', '6025650813658', {
-      'value': '0.00',
-      'currency': 'USD'
-    }]);
-  </script>
-  <!-- Facebook Pixel Code -->
-  <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
-
-    fbq('init', '1570461443220689');
-    fbq('track', "PageView");
-    fbq('track', 'ViewContent');
-    fbq('track', 'Search');
-  </script>
-  <noscript>
-    <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1570461443220689&ev=PageView&noscript=1"/>
-  </noscript>
-  <!-- End Facebook Pixel Code -->
-  <noscript>&lt;img height=1 width=1 alt="" style="display:none" src="https://www.facebook.com/tr?ev=6025650813658&amp;amp;cd[value]=0.00&amp;amp;cd[currency]=USD&amp;amp;noscript=1"/&gt;</noscript>
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
   <script>
     WebFont.load({

--- a/templates/new_layout.html
+++ b/templates/new_layout.html
@@ -43,40 +43,6 @@
 
     {% block adwords_conversion_code %}{% endblock %}
 
-    <script>
-      (function() {
-        var _fbq = window._fbq || (window._fbq = []);
-        if (!_fbq.loaded) {
-          var fbds = document.createElement('script');
-          fbds.async = true;
-          fbds.src = '//connect.facebook.net/en_US/fbds.js';
-          var s = document.getElementsByTagName('script')[0];
-          s.parentNode.insertBefore(fbds, s);
-          _fbq.loaded = true;
-        }
-      })();
-      window._fbq = window._fbq || [];
-      window._fbq.push(['track', '6025650813658', {
-        'value': '0.00',
-        'currency': 'USD'
-      }]);
-    </script>
-
-    <!-- Facebook Pixel Code -->
-    <script>
-      !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-      n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-      n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-      document,'script','https://connect.facebook.net/en_US/fbevents.js');
-
-      fbq('init', '1570461443220689');
-      fbq('track', "PageView");
-      fbq('track', 'ViewContent');
-      fbq('track', 'Search');
-    </script>
-    <!-- End Facebook Pixel Code -->
-
     <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
     <script>
       WebFont.load({
@@ -91,7 +57,6 @@
   <body>
     <noscript>
       <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P5L2Z5Z" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-      <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1570461443220689&ev=PageView&noscript=1" />
     </noscript>
 
     {% include 'includes/navbar_thin.html' %}


### PR DESCRIPTION
#### What's this PR do?
Removes FB Pixel and FB conversion tracking code that was included in the layout.html templates 

#### Why are we doing this? How does it help us?
Increase our site visitors' privacy; decrease page load time--impact on page load time probably varies quite a lot based on response speed of the FB endpoint, etc.

Bonus: FB doesn't need to know everything everyone does all the time, everywhere. 

#### How should this be manually tested?
On dev, bring up browser Inspector window, `Network` tab
Load any page, or click any link. Sort the `Initiator` or `Name` column. Both work.

FB Pixel: You should not see `fbevents.js` anywhere in the column. 
FB conversion tracking: You should not see `fbds.js` anywhere in the column. 

#### How should this change be communicated to end users?
Audience Team will certainly let us know if they want this back. Please see "TODOs / next steps" below for more details.

#### Are there any smells or added technical debt to note?
Nope. 

#### What are the relevant tickets?
[Remove advanced Facebook pixel tracking](https://3.basecamp.com/3098728/buckets/736178/todos/1754590629)
This task is an addendum to the above.

#### Have you done the following, if applicable:
* [ ] Added automated tests? *( uses existing )*
* [ ] Tested manually on mobile? *(  no diff )*
* [ ] Checked for performance implications? *( removing FB events which trigger API hits will improve performance )*
* [ ] Checked for security implications? *( no affect on site security )*
* [ ] Updated the documentation/wiki? *( no )*

#### TODOs / next steps:
Twitter pixel tracking under review. Moving to a more explicit and stronger site visitor privacy policy we're cleaning up old, possibly unused trackers. It's an ongoing process.