### PR TITLE
Add optional inputmode attr

### DIFF
--- a/static/js/src/elements/TextInput.vue
+++ b/static/js/src/elements/TextInput.vue
@@ -10,6 +10,7 @@
       :name="name"
       :placeholder="placeholder"
       :type="type"
+      :inputmode="inputmode"
       @input="updateSingleValue($event.target.value)"
     />
     <p v-if="showError && !isValid" role="alert">{{ message }}</p>
@@ -49,6 +50,12 @@ export default {
     type: {
       type: String,
       default: 'text',
+    },
+
+    inputmode: {
+      type: String,
+      default: null,
+      required: false,
     },
   },
 

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -38,6 +38,7 @@
             type="email"
             base-classes="form__text form__text--standard"
             name="stripeEmail"
+            inputmode="email"
           />
         </div>
       </div>
@@ -59,6 +60,7 @@
             label-text="website"
             base-classes="form__text form__text--standard"
             name="website"
+            inputmode="url"
           />
         </div>
       </div>
@@ -101,6 +103,7 @@
             label-text="zip code"
             base-classes="form__text form__text--standard"
             name="shipping_postalcode"
+            inputmode="numeric"
           />
         </div>
       </div>

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -37,6 +37,7 @@
             type="email"
             base-classes="form__text form__text--standard"
             name="stripeEmail"
+            inputmode="email"
           />
         </div>
       </div>
@@ -81,6 +82,7 @@
             label-text="zip code"
             base-classes="form__text form__text--standard"
             name="zipcode"
+            inputmode="numeric"
           />
         </div>
       </div>

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -33,6 +33,7 @@
           label-text="amount ($)"
           base-classes="form__text form__text--heavy"
           name="amount"
+          inputmode="decimal"
         />
       </div>
     </div>
@@ -55,6 +56,7 @@
           type="email"
           base-classes="form__text form__text--standard"
           name="stripeEmail"
+          inputmode="email"
         />
       </div>
     </div>
@@ -99,6 +101,7 @@
           label-text="zip code"
           base-classes="form__text form__text--standard"
           name="zipcode"
+          inputmode="numeric"
         />
       </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?

Adds an `inputmode` prop to our <TextInput/> component to render that attribute on text fields where the prop is passed.

#### Why are we doing this? How does it help us?

`inputmode` is a tiny UX enhancement for supported touch devices. Designating the `inputmode` sets the appropriate touch keyboard for a user and saves them from having to toggle to the correct character set when filling out our forms.

Inspired by this [CSS Tricks blog post](https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/)

> Unlike changing the type of the form, inputmode doesn’t change the way the browser interprets the input — it instructs the browser which keyboard to display.

#### How should this be manually tested?

Spin up locally and ensure the following:

- All Zip code fields: `inputmode="numeric"`

- All email fields: `inputmode="email"` (I think `type="email"` already provides the correct keyboard, so this one isn't completely necessary, but I figure can't hurt)

- All url fields: `inputmode=url`

- Donation amount field on /donate: `inputmode="decimal"` I didn't use numeric here because I'm assuming our form validation doesn't accept anything but numbers and decimals. This forces a number + decimal pad disallowing changing to letters, punctuation, etc. I feel fine about this since it matches the validation rules, but open to discuss.

- All remaining fields don't have the `inputmode` attribute at all.  (This is why you see `default=null` in the prop type definition. If there's a better way to force the attr to not show, let me know.)

Try it out on device and click around the form with this link: https://donations-testing-pr-208.herokuapp.com/donate

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Shouldn't be. 

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/1803780167

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [x] Tested manually on mobile? *( )*
* [x] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*


