### PR TITLE
Allow for filling first name, last name, zip and email by query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.19.0",
     "babel-loader": "^8.0.0",
     "css-loader": "^2.1.1",
+    "dompurify": "^1.0.10",
     "ds-toolbox-test": "https://github.com/texastribune/ds-toolbox.git#master",
     "es6-promise": "^4.2.4",
     "fast-async": "7",

--- a/static/js/src/entry/business/router.js
+++ b/static/js/src/entry/business/router.js
@@ -6,6 +6,7 @@ import VueRouter from 'vue-router';
 import RouteHandler from '../../RouteHandler.vue';
 import TopForm from './TopForm.vue';
 import mergeValuesIntoStartState from '../../utils/mergeValuesIntoStartState';
+import sanitizeParams from '../../utils/sanitize-params';
 import {
   BUSINESS_LEVELS,
   BUSINESS_FORM_STATE,
@@ -15,8 +16,9 @@ import {
 Vue.use(VueRouter);
 
 function getStateFromParams(queryParams) {
-  const { campaignId = '', referralId = '' } = queryParams;
-  let { level = DEFAULT_LEVEL } = queryParams;
+  const cleanParams = sanitizeParams(queryParams);
+  const { campaignId = '', referralId = '' } = cleanParams;
+  let { level = DEFAULT_LEVEL } = cleanParams;
 
   if (!BUSINESS_LEVELS[level]) level = DEFAULT_LEVEL;
 

--- a/static/js/src/entry/circle/router.js
+++ b/static/js/src/entry/circle/router.js
@@ -6,11 +6,14 @@ import RouteHandler from '../../RouteHandler.vue';
 import TopForm from './TopForm.vue';
 import Wall from './Wall.vue';
 import mergeValuesIntoStartState from '../../utils/mergeValuesIntoStartState';
+import sanitizeParams from '../../utils/sanitize-params';
 import { CIRCLE_LEVELS, CIRCLE_FORM_STATE, DEFAULT_LEVEL } from './constants';
 
 Vue.use(VueRouter);
 
 function getStateFromParams(queryParams) {
+  const cleanParams = sanitizeParams(queryParams);
+  let { level = DEFAULT_LEVEL } = cleanParams;
   const {
     campaignId = '',
     referralId = '',
@@ -18,8 +21,7 @@ function getStateFromParams(queryParams) {
     lastName = '',
     email = '',
     zipcode = '',
-  } = queryParams;
-  let { level = DEFAULT_LEVEL } = queryParams;
+  } = cleanParams;
 
   if (!CIRCLE_LEVELS[level]) level = DEFAULT_LEVEL;
 

--- a/static/js/src/entry/circle/router.js
+++ b/static/js/src/entry/circle/router.js
@@ -11,7 +11,14 @@ import { CIRCLE_LEVELS, CIRCLE_FORM_STATE, DEFAULT_LEVEL } from './constants';
 Vue.use(VueRouter);
 
 function getStateFromParams(queryParams) {
-  const { campaignId = '', referralId = '' } = queryParams;
+  const {
+    campaignId = '',
+    referralId = '',
+    firstName = '',
+    lastName = '',
+    email = '',
+    zipcode = '',
+  } = queryParams;
   let { level = DEFAULT_LEVEL } = queryParams;
 
   if (!CIRCLE_LEVELS[level]) level = DEFAULT_LEVEL;
@@ -21,6 +28,10 @@ function getStateFromParams(queryParams) {
   return {
     level,
     amount,
+    zipcode,
+    first_name: firstName,
+    last_name: lastName,
+    stripeEmail: email,
     installment_period: installmentPeriod,
     campaign_id: campaignId,
     referral_id: referralId,

--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -20,7 +20,14 @@ function createInitialFormState(queryParams) {
   }
 
   let { amount, installmentPeriod = 'monthly' } = queryParams;
-  const { campaignId = '', referralId = '' } = queryParams;
+  const {
+    campaignId = '',
+    referralId = '',
+    firstName = '',
+    lastName = '',
+    email = '',
+    zipcode = '',
+  } = queryParams;
 
   switch (installmentPeriod.toLowerCase()) {
     case 'once':
@@ -42,6 +49,10 @@ function createInitialFormState(queryParams) {
   // which contains validation information
   return mergeValuesIntoStartState(BASE_FORM_STATE, {
     amount,
+    zipcode,
+    first_name: firstName,
+    last_name: lastName,
+    stripeEmail: email,
     campaign_id: campaignId,
     referral_id: referralId,
     installment_period: installmentPeriod,

--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -5,6 +5,7 @@ import VueRouter from 'vue-router';
 import RouteHandler from '../../RouteHandler.vue';
 import TopForm from './TopForm.vue';
 import mergeValuesIntoStartState from '../../utils/mergeValuesIntoStartState';
+import sanitizeParams from '../../utils/sanitize-params';
 import { BASE_FORM_STATE } from './constants';
 
 Vue.use(VueRouter);
@@ -19,7 +20,8 @@ function createInitialFormState(queryParams) {
     );
   }
 
-  let { amount, installmentPeriod = 'monthly' } = queryParams;
+  const cleanParams = sanitizeParams(queryParams);
+  let { amount, installmentPeriod = 'monthly' } = cleanParams;
   const {
     campaignId = '',
     referralId = '',
@@ -27,7 +29,7 @@ function createInitialFormState(queryParams) {
     lastName = '',
     email = '',
     zipcode = '',
-  } = queryParams;
+  } = cleanParams;
 
   switch (installmentPeriod.toLowerCase()) {
     case 'once':

--- a/static/js/src/utils/sanitize-params.js
+++ b/static/js/src/utils/sanitize-params.js
@@ -1,0 +1,11 @@
+import DOMPurify from 'dompurify';
+
+export default function sanitizeParams(params) {
+  const sanitized = {};
+
+  Object.keys(params).forEach(key => {
+    sanitized[key] = DOMPurify.sanitize(params[key]);
+  });
+
+  return sanitized;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,6 +2794,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-1.0.10.tgz#18d7353631c86ee25049e38fbca8c6b2c5a2af87"
+  integrity sha512-huhl3DSWX5LaA7jDtnj3XQdJgWW1wYouNW7N0drGzQa4vEUSVWyeFN+Atx6HP4r5cang6oQytMom6I4yhGJj5g==
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
#### What's this PR do?
Adds support for following query params on `/donate` and `/circle`:
+ `firstName`
+ `lastName`
+ `zipcode`
+ `email`

Also uses DOMPurify package to sanitize query parameters. Vue already escapes everything, but I got paranoid and added this extra safeguard.

#### Why are we doing this? How does it help us?
Pre-UMP.

#### How should this be manually tested?
Try those params on both pages. Confirm the form inputs fill properly and default to empty values if a param is not provided.

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
NA.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/10357222/todos/1807641678

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [x] Checked for security implications?
* [ ] Updated the documentation/wiki?