### PR TITLE
Add back responsive image style to charge page and fix link

### DIFF
--- a/static/sass/charge.scss
+++ b/static/sass/charge.scss
@@ -11,6 +11,7 @@
 
 @import '6-components/buttons';
 @import '6-components/footer';
+@import '6-components/images';
 @import '6-components/navbar';
 
 @import '7-utilities/all';

--- a/templates/charge.html
+++ b/templates/charge.html
@@ -11,7 +11,7 @@
       </div>
       <div class="grid_row">
         <div class="prose">
-          <p>As a token of our appreciation, your membership includes a Proud Member sticker that we hope you’ll display with pride. If you’d like one, please <a href="http://www.tfaforms.com/4700837" target="_blank">tell us your mailing address</a>.</p>
+          <p>As a token of our appreciation, your membership includes a Proud Member sticker that we hope you’ll display with pride. If you’d like one, please <a href="http://www.tfaforms.com/4700837" target="_blank" rel="noopener noreferrer">tell us your mailing address</a>.</p>
           <p>You can help ensure the rest of Texas knows about our mission to inform and engage the public in politics and policy news by sharing your membership story now.</p>
           <p><strong>Why do you support The Texas Tribune?</strong></p>
         </div>


### PR DESCRIPTION
#### What's this PR do?

Add back width: 100% to image on charge page so it's responsive. Also fixes the only target="_blank" vulnerability in the repo.

#### Why are we doing this? How does it help us?

Better mobile experience after someone so kindly pays us.

#### How should this be manually tested?
`make`
`yarn run dev`
`make restart`
Fill out the donations form. Observe that the image should scale in a smaller viewport.

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
N/A
#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/1830119125

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [x] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
