### PR TITLE
Make portal environment variables required on heroku test builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,15 @@
     "AMAZON_SANDBOX": {
       "required": true
     },
+    "AUTH0_AUDIENCE": {
+      "required": true
+    },
+    "AUTH0_CLIENT_ID": {
+      "required": true
+    },
+    "AUTH0_DOMAIN": {
+      "required": true
+    },
     "BATCH_HOURS": {
       "required": true
     },
@@ -36,6 +45,9 @@
     "DEFAULT_MAIL_SENDER": {
       "required": true
     },
+    "ENABLE_PORTAL": {
+      "required": true
+    },    
     "ENABLE_SENTRY": {
       "required": true
     },
@@ -102,6 +114,12 @@
     "PAPERTRAIL_API_TOKEN": {
       "required": true
     },
+    "PORTAL_API_DOMAIN": {
+      "required": true
+    },
+    "PORTAL_CAMPAIGN_ID": {
+      "required": true
+    },
     "PUBLISHABLE_KEY": {
       "required": true
     },
@@ -132,10 +150,19 @@
     "SECRET_KEY": {
       "required": true
     },
+    "SENTRY_AUTH_TOKEN": {
+      "required": true
+    },
     "SENTRY_DSN": {
       "required": true
     },
     "SENTRY_ENVIRONMENT": {
+      "required": true
+    },
+    "SENTRY_ORG": {
+      "required": true
+    },
+    "SENTRY_PROJECT": {
       "required": true
     },
     "SLACK_API_KEY": {

--- a/app.json
+++ b/app.json
@@ -39,6 +39,9 @@
     "ENABLE_SENTRY": {
       "required": true
     },
+    "ENABLE_SENTRY_RELEASE": {
+      "required": true
+    },
     "ENABLE_SLACK": {
       "required": true
     },


### PR DESCRIPTION
#### What's this PR do?
Forces all [PR heroku test environments ](https://dashboard.heroku.com/apps/donations-testing/activity)to have the following variables

```
ENABLE_SENTRY_RELEASE
SENTRY_AUTH_TOKEN
SENTRY_ORG
SENTRY_PROJECT
PORTAL_CAMPAIGN_ID
ENABLE_PORTAL
AUTH0_AUDIENCE
PORTAL_API_DOMAIN
AUTH0_DOMAIN
AUTH0_CLIENT_ID
```

#### Why are we doing this? How does it help us?

Enables our PR test sites to start working again.

#### How should this be manually tested?

Hmm, probably can't until this is on master, but make sure I didn't miss any!

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Nope

#### What are the relevant tickets?

Leftover from portal launch

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
