### PR TITLE
Add support for code query parameter

### DIFF
--- a/static/js/src/entry/donate/constants.js
+++ b/static/js/src/entry/donate/constants.js
@@ -1,6 +1,12 @@
 import * as validators from '../../utils/validators';
 
-// eslint-disable-next-line import/prefer-default-export
+export const AMBASSADOR_CODES = {
+  'ump-1': {
+    installmentPeriod: 'monthly',
+    amount: '15',
+  },
+};
+
 export const BASE_FORM_STATE = {
   stripeEmail: {
     value: '',

--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -6,7 +6,7 @@ import RouteHandler from '../../RouteHandler.vue';
 import TopForm from './TopForm.vue';
 import mergeValuesIntoStartState from '../../utils/merge-values-into-start-state';
 import sanitizeParams from '../../utils/sanitize-params';
-import { BASE_FORM_STATE } from './constants';
+import { BASE_FORM_STATE, AMBASSADOR_CODES } from './constants';
 
 /* import Thermometer from './Thermometer.vue'; */
 
@@ -23,7 +23,6 @@ function createInitialFormState(queryParams) {
   }
 
   const cleanParams = sanitizeParams(queryParams);
-  let { amount, installmentPeriod = 'monthly' } = cleanParams;
   const {
     campaignId = '',
     referralId = '',
@@ -31,22 +30,31 @@ function createInitialFormState(queryParams) {
     lastName = '',
     email = '',
     zipcode = '',
+    code = '',
   } = cleanParams;
+  let amount;
+  let installmentPeriod;
 
-  switch (installmentPeriod.toLowerCase()) {
-    case 'once':
-      installmentPeriod = 'None';
-      amount = amount || '60';
-      break;
-    case 'monthly':
-      amount = amount || '35';
-      break;
-    case 'yearly':
-      amount = amount || '75';
-      break;
-    default:
-      installmentPeriod = 'monthly';
-      amount = amount || '35';
+  if (code) {
+    ({ amount, installmentPeriod } = AMBASSADOR_CODES[code]);
+  } else {
+    ({ amount, installmentPeriod = 'monthly' } = cleanParams);
+
+    switch (installmentPeriod.toLowerCase()) {
+      case 'once':
+        installmentPeriod = 'None';
+        amount = amount || '60';
+        break;
+      case 'monthly':
+        amount = amount || '35';
+        break;
+      case 'yearly':
+        amount = amount || '75';
+        break;
+      default:
+        installmentPeriod = 'monthly';
+        amount = amount || '35';
+    }
   }
 
   // merge query-parameter values into full state object,


### PR DESCRIPTION
#### What's this PR do?
Gets ambassador URLs working for portal read-write.

#### Why are we doing this? How does it help us?
All part of UMP life.

#### How should this be manually tested?
- `make`
- `make restart`
- Visit `/donations?code=ump-1&campaignId=12345&referralId=6789`
- Confirm the form populates with monthly and $15
- Confirm you can successfully submit and that campaign ID and referral ID show up in the Celery mess that appears :)

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
NA.

#### What are the relevant tickets?
UMP.

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked for security implications?
* [ ] Updated the documentation/wiki?