### PR TITLE
Center names in Circle wall print

### DIFF
--- a/static/sass/6-components/_wall.scss
+++ b/static/sass/6-components/_wall.scss
@@ -33,7 +33,7 @@
     }
 
     @media print {
-      display: initial;
+      justify-content: center;
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?
Centers (instead of left aligns) donor names when you print the Circle page.

#### Why are we doing this? How does it help us?
Jenny request.

#### How should this be manually tested?
Do a print preview of the page and confirm the names are centered.

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
NA.

#### What are the relevant tickets?
NA.

#### Have you done the following, if applicable:
* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*