### PR TITLE
Add reCAPTCHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Environment
 | `ENABLE_PORTAL`             |                                           True |
 | `PORTAL_API_DOMAIN`         |                            https://foo.bar/api |
 | `PORTAL_CAMPAIGN_ID`        |                             stringstringstring |
+| `RECAPTCHA_SECRET_KEY`      |                             stringstringstring |
+| `RECAPTCHA_SITE_KEY`        |                             stringstringstring |
 
 Running the Project
 -------------------

--- a/app.py
+++ b/app.py
@@ -362,7 +362,8 @@ def do_charge_or_show_errors(template, bundles, function, donation_type):
         return render_template(
             template,
             bundles=bundles,
-            key=app.config["STRIPE_KEYS"]["publishable_key"],
+            stripe=app.config["STRIPE_KEYS"]["publishable_key"],
+            recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
             message=message,
             form_data=form_data,
         )

--- a/app.py
+++ b/app.py
@@ -435,7 +435,10 @@ def donate_form():
         return validate_form(DonateForm, bundles=bundles, template=template)
 
     return render_template(
-        template, bundles=bundles, key=app.config["STRIPE_KEYS"]["publishable_key"]
+        template,
+        bundles=bundles,
+        stripe=app.config["STRIPE_KEYS"]["publishable_key"],
+        recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
     )
 
 
@@ -448,7 +451,10 @@ def circle_form():
         return validate_form(CircleForm, bundles=bundles, template=template)
 
     return render_template(
-        template, bundles=bundles, key=app.config["STRIPE_KEYS"]["publishable_key"]
+        template,
+        bundles=bundles,
+        stripe=app.config["STRIPE_KEYS"]["publishable_key"],
+        recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
     )
 
 
@@ -466,7 +472,10 @@ def business_form():
         )
 
     return render_template(
-        template, bundles=bundles, key=app.config["STRIPE_KEYS"]["publishable_key"]
+        template,
+        bundles=bundles,
+        stripe=app.config["STRIPE_KEYS"]["publishable_key"],
+        recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
     )
 
 

--- a/config.py
+++ b/config.py
@@ -78,6 +78,14 @@ SENTRY_DSN = os.getenv("SENTRY_DSN")
 SENTRY_ENVIRONMENT = os.getenv("SENTRY_ENVIRONMENT", "unknown")
 REPORT_URI = os.getenv("REPORT_URI")
 
+########
+# Recaptcha
+#
+RECAPTCHA_KEYS = {
+    "secret_key": os.getenv("RECAPTCHA_SECRET_KEY"),
+    "site_key": os.getenv("RECAPTCHA_SITE_KEY"),
+}
+
 #######
 # Portal
 #

--- a/forms.py
+++ b/forms.py
@@ -40,6 +40,7 @@ class BaseForm(FlaskForm):
         "Email address", [validators.DataRequired(), validators.Email()]
     )
     stripeToken = HiddenField(u"Stripe token", [validators.InputRequired()])
+    captchaToken = HiddenField(u"Captcha token", [validators.InputRequired()])
     description = HiddenField(u"Description", [validators.InputRequired()])
     pay_fees_value = HiddenField(
         u"Pay Fees Value", [validators.AnyOf(["True", "False"])]

--- a/forms.py
+++ b/forms.py
@@ -40,7 +40,7 @@ class BaseForm(FlaskForm):
         "Email address", [validators.DataRequired(), validators.Email()]
     )
     stripeToken = HiddenField(u"Stripe token", [validators.InputRequired()])
-    captchaToken = HiddenField(u"Captcha token", [validators.InputRequired()])
+    recaptchaToken = HiddenField(u"Recaptcha token", [validators.InputRequired()])
     description = HiddenField(u"Description", [validators.InputRequired()])
     pay_fees_value = HiddenField(
         u"Pay Fees Value", [validators.AnyOf(["True", "False"])]

--- a/static/js/src/connected-elements/ManualPay.vue
+++ b/static/js/src/connected-elements/ManualPay.vue
@@ -8,6 +8,8 @@
 <script>
 import { Card } from 'vue-stripe-elements-plus';
 
+import { STRIPE_KEY } from '../constants';
+
 export default {
   name: 'ManualPay',
 
@@ -38,8 +40,7 @@ export default {
 
   computed: {
     stripeKey() {
-      // eslint-disable-next-line no-underscore-dangle
-      return window.__STRIPE_KEY__;
+      return STRIPE_KEY;
     },
 
     isValid() {

--- a/static/js/src/connected-elements/NativePay.vue
+++ b/static/js/src/connected-elements/NativePay.vue
@@ -19,6 +19,9 @@
 
 import Vue from 'vue';
 
+import getRecaptchaToken from '../utils/get-recaptcha-token';
+import { RECAPTCHA_ERROR_MESSAGE, STRIPE_KEY } from '../constants';
+
 export default {
   name: 'NativePay',
 
@@ -71,7 +74,7 @@ export default {
   methods: {
     buildNativePayment() {
       // eslint-disable-next-line no-underscore-dangle
-      const stripe = new Stripe(window.__STRIPE_KEY__);
+      const stripe = new Stripe(STRIPE_KEY);
       const paymentRequest = stripe.paymentRequest({
         country: 'US',
         currency: 'usd',
@@ -99,6 +102,7 @@ export default {
               key: 'nativeIsSupported',
               value: true,
             });
+
             button.mount(this.$refs.native);
           } else {
             throw new Error();
@@ -113,26 +117,40 @@ export default {
           { key: 'showErrors', value: true },
           { key: 'showCardError', value: false },
           { key: 'serverErrorMessage', value: '' },
+          { key: 'genericErrorMessage', value: '' },
         ];
 
         this.$emit('setLocalValue', updates);
+
         if (!this.formIsValid) event.preventDefault();
       });
 
-      paymentRequest.on('token', event => {
+      paymentRequest.on('token', async event => {
         const {
           token: { id },
         } = event;
 
-        this.$emit('setLocalValue', {
-          key: 'stripeToken',
-          value: id,
-        });
+        try {
+          const captchaToken = await getRecaptchaToken('manualPay');
 
-        event.complete('success');
-        Vue.nextTick(() => {
-          this.$emit('onSubmit');
-        });
+          this.$emit('setLocalValues', [
+            { key: 'stripeToken', value: id },
+            { key: 'captchaToken', value: captchaToken },
+          ]);
+
+          event.complete('success');
+
+          Vue.nextTick(() => {
+            this.$emit('onSubmit');
+          });
+        } catch (err) {
+          this.$emit('setLocalValue', {
+            key: 'genericErrorMessage',
+            value: RECAPTCHA_ERROR_MESSAGE,
+          });
+
+          event.complete('fail');
+        }
       });
     },
 

--- a/static/js/src/constants.js
+++ b/static/js/src/constants.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
 export const RECAPTCHA_ERROR_MESSAGE =
-  'There was an error validating your form information. Please try submitting the form again. If the issue persists, contact inquiries@texastribune.org.';
+  'There was an error submitting your donation. Please try again. If the issue persists, contact membership@texastribune.org.';
 
 export const STRIPE_KEY = window.__STRIPE_KEY__;
 

--- a/static/js/src/constants.js
+++ b/static/js/src/constants.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-underscore-dangle */
+
+export const RECAPTCHA_ERROR_MESSAGE =
+  'There was an error validating your form information. Please try submitting the form again. If the issue persists, contact inquiries@texastribune.org.';
+
+export const STRIPE_KEY = window.__STRIPE_KEY__;
+
+export const RECAPTCHA_KEY = window.__RECAPTCHA_KEY__;

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -153,6 +153,7 @@
             :supported="nativeIsSupported"
             base-classes="form__native"
             @setLocalValue="setLocalValue"
+            @setCardValue="setCardValue"
             @onSubmit="onSubmit"
           />
         </div>
@@ -172,7 +173,6 @@
           <div class="grid_row">
             <div class="col">
               <manual-pay
-                :show-error="showErrors && showCardError"
                 :card="card"
                 base-classes="form__manual"
                 @setCardValue="setCardValue"
@@ -201,7 +201,7 @@
         </p>
       </div>
 
-      <div v-if="genericErrorMessage">
+      <div v-if="genericErrorMessage" class="grid_separator">
         <div class="grid_row">
           <div class="col">
             <p class="form__error form__error--normal form__error--centered">
@@ -211,8 +211,14 @@
         </div>
       </div>
 
+      <p class="subtext">
+        This site is protected by reCAPTCHA and the Google
+        <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+        <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+      </p>
+
       <local-hidden :value="stripeToken" name="stripeToken" />
-      <local-hidden :value="captchaToken" name="captchaToken" />
+      <local-hidden :value="recaptchaToken" name="recaptchaToken" />
       <hidden name="campaign_id" :store-module="storeModule" />
       <hidden name="referral_id" :store-module="storeModule" />
       <hidden name="description" :store-module="storeModule" />
@@ -228,10 +234,10 @@ import Hidden from '../../connected-elements/Hidden.vue';
 import PayFees from '../../connected-elements/PayFees.vue';
 import TextInput from '../../connected-elements/TextInput.vue';
 import SelectList from '../../connected-elements/SelectList.vue';
-import ManualPay from '../../connected-elements/ManualPay.vue';
-import ManualSubmit from '../../connected-elements/ManualSubmit.vue';
-import NativePay from '../../connected-elements/NativePay.vue';
 import FormBuckets from '../../connected-elements/FormBuckets.vue';
+import ManualPay from '../../payment-elements/ManualPay.vue';
+import ManualSubmit from '../../payment-elements/ManualSubmit.vue';
+import NativePay from '../../payment-elements/NativePay.vue';
 import LocalHidden from '../../local-elements/Hidden.vue';
 import Benefits from './Benefits.vue';
 import formStarter from '../../mixins/connected-form/starter';

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -6,10 +6,7 @@
     class="form business-form"
     @submit="$event.preventDefault()"
   >
-    <div
-      v-show="showServerErrorMessage"
-      class="grid_container--l grid_separator"
-    >
+    <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
           <p class="form__error form__error--prominent">
@@ -167,7 +164,10 @@
         aria-hidden="true"
       />
 
-      <div :aria-live="nativeIsSupported ? 'polite' : false">
+      <div
+        :aria-live="nativeIsSupported ? 'polite' : false"
+        class="grid_separator"
+      >
         <div v-if="showManualPay">
           <div class="grid_row">
             <div class="col">
@@ -194,23 +194,25 @@
             </div>
           </div>
         </div>
+
         <p class="subtext">
           The Texas Tribune is a 501(c)(3), and your organization's gift is tax
           deductible
         </p>
       </div>
 
-      <div v-if="showErrorClue" class="grid_separator--l" aria-hidden="true" />
-
-      <div v-if="showErrorClue" class="grid_row" aria-hidden="true">
-        <div class="col">
-          <p class="form__error form__error--normal form__error--centered">
-            Please correct errors above
-          </p>
+      <div v-if="genericErrorMessage">
+        <div class="grid_row">
+          <div class="col">
+            <p class="form__error form__error--normal form__error--centered">
+              {{ genericErrorMessage }}
+            </p>
+          </div>
         </div>
       </div>
 
       <local-hidden :value="stripeToken" name="stripeToken" />
+      <local-hidden :value="captchaToken" name="captchaToken" />
       <hidden name="campaign_id" :store-module="storeModule" />
       <hidden name="referral_id" :store-module="storeModule" />
       <hidden name="description" :store-module="storeModule" />

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -204,7 +204,10 @@
       <div v-if="genericErrorMessage" class="grid_separator">
         <div class="grid_row">
           <div class="col">
-            <p class="form__error form__error--normal form__error--centered">
+            <p
+              role="alert"
+              class="form__error form__error--normal form__error--centered"
+            >
               {{ genericErrorMessage }}
             </p>
           </div>

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -144,7 +144,10 @@
       <div v-if="genericErrorMessage" class="grid_separator">
         <div class="grid_row">
           <div class="col">
-            <p class="form__error form__error--normal form__error--centered">
+            <p
+              role="alert"
+              class="form__error form__error--normal form__error--centered"
+            >
               {{ genericErrorMessage }}
             </p>
           </div>

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -6,10 +6,7 @@
     class="form circle-form"
     @submit="$event.preventDefault()"
   >
-    <div
-      v-show="showServerErrorMessage"
-      class="grid_container--l grid_separator"
-    >
+    <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
           <p class="form__error form__error--prominent">
@@ -112,7 +109,10 @@
         aria-hidden="true"
       />
 
-      <div :aria-live="nativeIsSupported ? 'polite' : false">
+      <div
+        :aria-live="nativeIsSupported ? 'polite' : false"
+        class="grid_separator"
+      >
         <div v-if="showManualPay">
           <div class="grid_row">
             <div class="col">
@@ -141,17 +141,18 @@
         </div>
       </div>
 
-      <div v-if="showErrorClue" class="grid_separator--l" aria-hidden="true" />
-
-      <div v-if="showErrorClue" class="grid_row" aria-hidden="true">
-        <div class="col">
-          <p class="form__error form__error--normal form__error--centered">
-            Please correct errors above
-          </p>
+      <div v-if="genericErrorMessage">
+        <div class="grid_row">
+          <div class="col">
+            <p class="form__error form__error--normal form__error--centered">
+              {{ genericErrorMessage }}
+            </p>
+          </div>
         </div>
       </div>
 
       <local-hidden :value="stripeToken" name="stripeToken" />
+      <local-hidden :value="captchaToken" name="captchaToken" />
       <hidden name="amount" :store-module="storeModule" />
       <hidden name="installment_period" :store-module="storeModule" />
       <hidden name="description" :store-module="storeModule" />

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -98,6 +98,7 @@
             :supported="nativeIsSupported"
             base-classes="form__native"
             @setLocalValue="setLocalValue"
+            @setCardValue="setCardValue"
             @onSubmit="onSubmit"
           />
         </div>
@@ -117,7 +118,6 @@
           <div class="grid_row">
             <div class="col">
               <manual-pay
-                :show-error="showErrors && showCardError"
                 :card="card"
                 base-classes="form__manual"
                 @setCardValue="setCardValue"
@@ -141,7 +141,7 @@
         </div>
       </div>
 
-      <div v-if="genericErrorMessage">
+      <div v-if="genericErrorMessage" class="grid_separator">
         <div class="grid_row">
           <div class="col">
             <p class="form__error form__error--normal form__error--centered">
@@ -151,8 +151,14 @@
         </div>
       </div>
 
+      <p class="subtext">
+        This site is protected by reCAPTCHA and the Google
+        <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+        <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+      </p>
+
       <local-hidden :value="stripeToken" name="stripeToken" />
-      <local-hidden :value="captchaToken" name="captchaToken" />
+      <local-hidden :value="recaptchaToken" name="recaptchaToken" />
       <hidden name="amount" :store-module="storeModule" />
       <hidden name="installment_period" :store-module="storeModule" />
       <hidden name="description" :store-module="storeModule" />
@@ -167,10 +173,10 @@
 import Hidden from '../../connected-elements/Hidden.vue';
 import PayFees from '../../connected-elements/PayFees.vue';
 import TextInput from '../../connected-elements/TextInput.vue';
-import ManualPay from '../../connected-elements/ManualPay.vue';
-import ManualSubmit from '../../connected-elements/ManualSubmit.vue';
-import NativePay from '../../connected-elements/NativePay.vue';
 import FormBuckets from '../../connected-elements/FormBuckets.vue';
+import ManualPay from '../../payment-elements/ManualPay.vue';
+import ManualSubmit from '../../payment-elements/ManualSubmit.vue';
+import NativePay from '../../payment-elements/NativePay.vue';
 import LocalHidden from '../../local-elements/Hidden.vue';
 import formStarter from '../../mixins/connected-form/starter';
 import { CIRCLE_LEVELS } from './constants';

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -6,7 +6,7 @@
     class="form"
     @submit="$event.preventDefault()"
   >
-    <div v-show="serverErrorMessage" class="grid_row grid_separator">
+    <div v-if="serverErrorMessage" class="grid_row grid_separator">
       <div class="col">
         <p class="form__error form__error--prominent">
           {{ serverErrorMessage }}
@@ -120,6 +120,7 @@
           :supported="nativeIsSupported"
           base-classes="form__native"
           @setLocalValue="setLocalValue"
+          @setCardValue="setCardValue"
           @onSubmit="onSubmit"
         />
       </div>
@@ -139,7 +140,6 @@
         <div class="grid_row">
           <div class="col">
             <manual-pay
-              :show-error="showErrors && showCardError"
               :card="card"
               base-classes="form__manual"
               @setCardValue="setCardValue"
@@ -163,7 +163,7 @@
       </div>
     </div>
 
-    <div v-if="genericErrorMessage">
+    <div v-if="genericErrorMessage" class="grid_separator">
       <div class="grid_row">
         <div class="col">
           <p class="form__error form__error--normal form__error--centered">
@@ -173,8 +173,14 @@
       </div>
     </div>
 
+    <p class="subtext">
+      This site is protected by reCAPTCHA and the Google
+      <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+      <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+    </p>
+
     <local-hidden :value="stripeToken" name="stripeToken" />
-    <local-hidden :value="captchaToken" name="captchaToken" />
+    <local-hidden :value="recaptchaToken" name="recaptchaToken" />
     <hidden name="description" :store-module="storeModule" />
     <hidden name="campaign_id" :store-module="storeModule" />
     <hidden name="referral_id" :store-module="storeModule" />
@@ -188,10 +194,10 @@ import LocalHidden from '../../local-elements/Hidden.vue';
 import Radios from '../../connected-elements/Radios.vue';
 import PayFees from '../../connected-elements/PayFees.vue';
 import TextInput from '../../connected-elements/TextInput.vue';
-import ManualPay from '../../connected-elements/ManualPay.vue';
-import ManualSubmit from '../../connected-elements/ManualSubmit.vue';
-import NativePay from '../../connected-elements/NativePay.vue';
 import updateValue from '../../connected-elements/mixins/update-value';
+import ManualPay from '../../payment-elements/ManualPay.vue';
+import ManualSubmit from '../../payment-elements/ManualSubmit.vue';
+import NativePay from '../../payment-elements/NativePay.vue';
 import formStarter from '../../mixins/connected-form/starter';
 
 export default {

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -6,7 +6,7 @@
     class="form"
     @submit="$event.preventDefault()"
   >
-    <div v-show="showServerErrorMessage" class="grid_row grid_separator">
+    <div v-show="serverErrorMessage" class="grid_row grid_separator">
       <div class="col">
         <p class="form__error form__error--prominent">
           {{ serverErrorMessage }}
@@ -131,7 +131,10 @@
       aria-hidden="true"
     />
 
-    <div :aria-live="nativeIsSupported ? 'polite' : false">
+    <div
+      :aria-live="nativeIsSupported ? 'polite' : false"
+      class="grid_separator"
+    >
       <div v-if="showManualPay">
         <div class="grid_row">
           <div class="col">
@@ -160,17 +163,18 @@
       </div>
     </div>
 
-    <div v-if="showErrorClue" class="grid_separator--l" aria-hidden="true" />
-
-    <div v-if="showErrorClue" class="grid_row" aria-hidden="true">
-      <div class="col">
-        <p class="form__error form__error--normal form__error--centered">
-          Please correct errors above
-        </p>
+    <div v-if="genericErrorMessage">
+      <div class="grid_row">
+        <div class="col">
+          <p class="form__error form__error--normal form__error--centered">
+            {{ genericErrorMessage }}
+          </p>
+        </div>
       </div>
     </div>
 
     <local-hidden :value="stripeToken" name="stripeToken" />
+    <local-hidden :value="captchaToken" name="captchaToken" />
     <hidden name="description" :store-module="storeModule" />
     <hidden name="campaign_id" :store-module="storeModule" />
     <hidden name="referral_id" :store-module="storeModule" />

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -166,7 +166,10 @@
     <div v-if="genericErrorMessage" class="grid_separator">
       <div class="grid_row">
         <div class="col">
-          <p class="form__error form__error--normal form__error--centered">
+          <p
+            role="alert"
+            class="form__error form__error--normal form__error--centered"
+          >
             {{ genericErrorMessage }}
           </p>
         </div>

--- a/static/js/src/errors.js
+++ b/static/js/src/errors.js
@@ -1,0 +1,20 @@
+// from: https://github.com/coralproject/talk/blob/v4.10.3/errors.js
+class ExtendableError {
+  constructor(message = null) {
+    this.message = message;
+    this.stack = new Error(message).stack;
+  }
+}
+
+export class RecaptchaError extends ExtendableError {
+  constructor() {
+    super('Failed to get recaptcha token');
+  }
+}
+
+export class StripeError extends ExtendableError {
+  constructor(message, type) {
+    super(message);
+    this.type = type;
+  }
+}

--- a/static/js/src/mixins/connected-form/starter.js
+++ b/static/js/src/mixins/connected-form/starter.js
@@ -8,6 +8,8 @@ export default {
         message: 'Your card number is incomplete',
       },
       stripeToken: '',
+      captchaToken: '',
+      genericErrorMessage: '',
       showErrors: false,
       showCardError: false,
       showManualPay: false,
@@ -24,19 +26,6 @@ export default {
       const invalids = Object.keys(fields).filter(key => !fields[key].isValid);
 
       return invalids.length === 0;
-    },
-
-    // whether to show "please correct errors above" below form
-    showErrorClue() {
-      if (this.showCardError && !this.card.isValid) return true;
-      if (this.showErrors && !this.isValid) return true;
-
-      return false;
-    },
-
-    // whether to show card-failure message produced on the server
-    showServerErrorMessage() {
-      return !this.showErrorClue && this.serverErrorMessage;
     },
   },
 

--- a/static/js/src/mixins/connected-form/starter.js
+++ b/static/js/src/mixins/connected-form/starter.js
@@ -5,13 +5,13 @@ export default {
       // at the Vuex level
       card: {
         isValid: false,
-        message: 'Your card number is incomplete',
+        errorMessage: 'Your card number is incomplete',
+        showError: false,
       },
       stripeToken: '',
-      captchaToken: '',
+      recaptchaToken: '',
       genericErrorMessage: '',
       showErrors: false,
-      showCardError: false,
       showManualPay: false,
       nativeIsSupported: false,
       isFetchingToken: false,

--- a/static/js/src/payment-elements/ManualPay.vue
+++ b/static/js/src/payment-elements/ManualPay.vue
@@ -18,11 +18,6 @@ export default {
   },
 
   props: {
-    showError: {
-      type: Boolean,
-      default: false,
-    },
-
     card: {
       type: Object,
       required: true,
@@ -47,8 +42,12 @@ export default {
       return this.card.isValid;
     },
 
+    showError() {
+      return this.card.showError;
+    },
+
     message() {
-      return this.card.message;
+      return this.card.errorMessage;
     },
 
     classesWithValidation() {
@@ -76,7 +75,7 @@ export default {
 
       this.$emit('setCardValue', [
         { key: 'isValid', value: validValue },
-        { key: 'message', value: messageValue },
+        { key: 'errorMessage', value: messageValue },
       ]);
     },
   },

--- a/static/js/src/payment-elements/ManualSubmit.vue
+++ b/static/js/src/payment-elements/ManualSubmit.vue
@@ -51,26 +51,27 @@ export default {
     async onClick() {
       this.$emit('setLocalValue', [
         { key: 'showErrors', value: true },
-        { key: 'showCardError', value: true },
         { key: 'serverErrorMessage', value: '' },
         { key: 'genericErrorMessage', value: '' },
       ]);
+
+      this.$emit('setCardValue', { key: 'showError', value: true });
 
       if (this.formIsValid) {
         this.markFetchingToken();
 
         try {
-          let captchaToken;
+          let recaptchaToken;
 
           try {
-            captchaToken = await getRecaptchaToken('manualPay');
+            recaptchaToken = await getRecaptchaToken('manualPay');
           } catch (err) {
             throw new RecaptchaError();
           }
 
           this.$emit('setLocalValue', {
-            key: 'captchaToken',
-            value: captchaToken,
+            key: 'recaptchaToken',
+            value: recaptchaToken,
           });
 
           const stripeResult = await createToken();
@@ -107,7 +108,7 @@ export default {
 
             this.$emit('setCardValue', [
               { key: 'isValid', value: false },
-              { key: 'message', value: messageToShow },
+              { key: 'errorMessage', value: messageToShow },
             ]);
           }
         }

--- a/static/js/src/payment-elements/NativePay.vue
+++ b/static/js/src/payment-elements/NativePay.vue
@@ -113,14 +113,13 @@ export default {
         });
 
       button.on('click', event => {
-        const updates = [
+        this.$emit('setLocalValue', [
           { key: 'showErrors', value: true },
-          { key: 'showCardError', value: false },
           { key: 'serverErrorMessage', value: '' },
           { key: 'genericErrorMessage', value: '' },
-        ];
+        ]);
 
-        this.$emit('setLocalValue', updates);
+        this.$emit('setCardValue', { key: 'showError', value: false });
 
         if (!this.formIsValid) event.preventDefault();
       });
@@ -131,11 +130,11 @@ export default {
         } = event;
 
         try {
-          const captchaToken = await getRecaptchaToken('manualPay');
+          const recaptchaToken = await getRecaptchaToken('nativePay');
 
-          this.$emit('setLocalValues', [
+          this.$emit('setLocalValue', [
             { key: 'stripeToken', value: id },
-            { key: 'captchaToken', value: captchaToken },
+            { key: 'recaptchaToken', value: recaptchaToken },
           ]);
 
           event.complete('success');

--- a/static/js/src/utils/get-recaptcha-token.js
+++ b/static/js/src/utils/get-recaptcha-token.js
@@ -1,0 +1,23 @@
+import { RecaptchaError } from '../errors';
+import { RECAPTCHA_KEY } from '../constants';
+
+export default function getRecaptchaToken(action) {
+  const { grecaptcha } = window;
+
+  return new Promise((resolve, reject) => {
+    try {
+      grecaptcha.ready(() => {
+        grecaptcha
+          // eslint-disable-next-line no-underscore-dangle
+          .execute(RECAPTCHA_KEY, {
+            action,
+          })
+          .then(token => {
+            resolve(token);
+          });
+      });
+    } catch (err) {
+      reject(new RecaptchaError());
+    }
+  });
+}

--- a/static/sass/6-components/_forms.scss
+++ b/static/sass/6-components/_forms.scss
@@ -190,3 +190,8 @@
     }
   }
 }
+
+// hide reCAPTCHA badge
+.grecaptcha-badge {
+  visibility: hidden;
+}

--- a/templates/business-form.html
+++ b/templates/business-form.html
@@ -52,16 +52,22 @@
 {% endblock %}
 
 {% block bottom_script %}
-<script src="https://js.stripe.com/v3/"></script>
+  <script>
+    window.__STRIPE_KEY__ = '{{ stripe }}';
+    window.__RECAPTCHA_KEY__ = '{{ recaptcha }}';
+  </script>
 
-{% if form_data and message %}
-<script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
-  window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data|tojson }};
-</script>
-{% endif %}
+  {% if form_data and message %}
+  <script>
+    window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message | tojson }};
+    window.__BUSINESS_FORM_REHYDRATION__ = {{ form_data | tojson }};
+  </script>
+  {% endif %}
 
-{% for script in bundles['js'] %}
-  <script src="{{ script }}"></script>
-{% endfor %}
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="https://www.google.com/recaptcha/api.js?render={{ recaptcha }}"></script>
+
+  {% for script in bundles['js'] %}
+    <script src="{{ script }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -120,16 +120,22 @@
 {% endblock %}
 
 {% block bottom_script %}
-<script src="https://js.stripe.com/v3/"></script>
+  <script>
+    window.__STRIPE_KEY__ = '{{ stripe }}';
+    window.__RECAPTCHA_KEY__ = '{{ recaptcha }}';
+  </script>
 
-{% if form_data and message %}
-<script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
-  window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data|tojson }};
-</script>
-{% endif %}
+  {% if form_data and message %}
+  <script>
+    window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
+    window.__CIRCLE_FORM_REHYDRATION__ = {{ form_data|tojson }};
+  </script>
+  {% endif %}
 
-{% for script in bundles['js'] %}
-  <script src="{{ script }}"></script>
-{% endfor %}
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="https://www.google.com/recaptcha/api.js?render={{ recaptcha }}"></script>
+
+  {% for script in bundles['js'] %}
+    <script src="{{ script }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -61,16 +61,22 @@
 {% endblock %}
 
 {% block bottom_script %}
-<script src="https://js.stripe.com/v3/"></script>
+  <script>
+    window.__STRIPE_KEY__ = '{{ stripe }}';
+    window.__RECAPTCHA_KEY__ = '{{ recaptcha }}';
+  </script>
 
-{% if form_data and message %}
-<script>
-  window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
-  window.__BASE_FORM_REHYDRATION__ = {{ form_data|tojson }};
-</script>
-{% endif %}
+  {% if form_data and message %}
+  <script>
+    window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
+    window.__BASE_FORM_REHYDRATION__ = {{ form_data|tojson }};
+  </script>
+  {% endif %}
 
-{% for script in bundles['js'] %}
-  <script src="{{ script }}"></script>
-{% endfor %}
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="https://www.google.com/recaptcha/api.js?render={{ recaptcha }}"></script>
+
+  {% for script in bundles['js'] %}
+    <script src="{{ script }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/templates/new_layout.html
+++ b/templates/new_layout.html
@@ -72,10 +72,6 @@
 
     {% include 'includes/footer.html' %}
 
-    <script>
-      window.__STRIPE_KEY__ = '{{ key }}';
-    </script>
-
     {% block bottom_script %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
#### What's this PR do?
+ Adds reCAPTCHA to the Circle, BusMem and donation forms
+ Does a little bit of front-end refactoring, reorganization and renaming

#### Why are we doing this? How does it help us?
To help squash card testers.

#### How should this be manually tested?
First, ensure you have `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` in your `env-docker`.

Confirm you can submit the forms on `/business`, `/circle` and `/donate` -- and that, when you do, a hidden field called `recaptchaToken` is sent to Python.

#### How should this change be communicated to end users?
TBD. Right now, all we're doing is including a required sentence giving reCAPTCHA some love.

As far as what we should eventually do (cc @x110dc): If the back end determines the behavior is suspicious, we could reload the form with an error message at the top like we do [here](https://github.com/texastribune/donations/blob/master/app.py#L355-L368) when there's a Stripe card error.

#### Are there any smells or added technical debt to note?
Don't think so.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/2063412564

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked for security implications?
* [ ] Updated the documentation/wiki?

#### TODOs
* [ ] Collect data for a while
* [ ] Add messaging to form when behavior is suspicious
* [ ] Figure out what to call `action`s

@x110dc Do you have a preference what we call the `action`s (see [here](https://developers.google.com/recaptcha/docs/v3#actions)). Right now, they're set to `manualPay` for manual card-entry submissions and `nativePay` for Apple Pay/Google Pay/other "native" submissions. I can change them to whatever.