### PR TITLE
Revert FMD19

### DIFF
--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -8,7 +8,7 @@ import mergeValuesIntoStartState from '../../utils/merge-values-into-start-state
 import sanitizeParams from '../../utils/sanitize-params';
 import { BASE_FORM_STATE, AMBASSADOR_CODES } from './constants';
 
-import Thermometer from './Thermometer.vue';
+// import Thermometer from './Thermometer.vue';
 
 Vue.use(VueRouter);
 
@@ -82,7 +82,7 @@ function createRouter() {
 function bindRouterEvents(router, routeHandler, store) {
   router.onReady(() => {
     const topForm = new Vue({ ...TopForm, store });
-    const thermometer = new Vue({ ...Thermometer });
+    // const thermometer = new Vue({ ...Thermometer });
     const {
       currentRoute: { query },
     } = router;
@@ -94,7 +94,7 @@ function bindRouterEvents(router, routeHandler, store) {
 
     routeHandler.$mount('#app');
     topForm.$mount('#top-form');
-    thermometer.$mount('#thermometer');
+    // thermometer.$mount('#thermometer');
   });
 }
 

--- a/static/sass/6-components/_splash.scss
+++ b/static/sass/6-components/_splash.scss
@@ -1,15 +1,15 @@
 .splash {
   background-color: $color-sand;
   background-position-x: 50%;
-  //background-image: url('../img/TT-SMD18-BG_pattern-tile-trim.png');
+  background-image: url('../img/TT-SMD18-BG_pattern-tile-trim.png');
   background-repeat: repeat;
   padding: 0 $size-b;
   color: $color-white-pure;
 
   //FMD variation
-  background-image: url('../img/TT-FMD18-BG_pattern-tile-grey.png');
-  padding-bottom: $size-giant*2;
-  padding-top: $size-giant*2;
+  // background-image: url('../img/TT-FMD18-BG_pattern-tile-grey.png');
+  // padding-bottom: $size-giant*2;
+  // padding-top: $size-giant*2;
   //end FMD variation
 
   &--blast {
@@ -21,11 +21,12 @@
   &--tall {
     padding: ($size-giant * 2) 0;
     @include mq($until: bp-l) {
+      padding-bottom: $size-b;
+      padding-top: $size-b;
+
       //FMD variation
-      // padding-bottom: $size-b;
-      // padding-top: $size-b;
-      padding-bottom: $size-l;
-      padding-top: $size-l;
+      // padding-bottom: $size-l;
+      // padding-top: $size-l;
       //end FMD variation
     }
   }
@@ -34,7 +35,7 @@
     padding-bottom: $size-l;
 
     //FMD variation
-    color: $color-fmd-blue-dark;
+    //color: $color-fmd-blue-dark;
     //end FMD variation
 
     @include mq($from: bp-m) {
@@ -62,8 +63,8 @@
     font-size: $size-b;
 
     //FMD variation
-    @extend %link--blue;
-    color: $color-fmd-blue-dark;
+    // @extend %link--blue;
+    // color: $color-fmd-blue-dark;
     //end FMD variation
   }
 
@@ -83,26 +84,32 @@
       text-align: right;
     }
   }
+  
+  &__actions {
+    @include mq($until: bp-m) {
+      margin-top: 2rem;
+    }
+  }
 
   //FMD variation
-  &_actions {
-    align-items: center;
-  }
-  &--buttons {
-    .button {
-      width: 45%;
-    }
-    .button--yellow {
-      background-color: $color-fmd-blue-light;
-      border: 2px solid $color-fmd-blue-light;
-      color: $color-white-pure;
-    }
-    .text {
-      color: $color-fmd-blue-dark;
-      font-size: $size-xs;
-      padding-left: $size-xxs/2;
-      padding-right: $size-xxs/2;
-    }
-  }
+  // &_actions {
+  //   align-items: center;
+  // }
+  // &--buttons {
+  //   .button {
+  //     width: 45%;
+  //   }
+  //   .button--yellow {
+  //     background-color: $color-fmd-blue-light;
+  //     border: 2px solid $color-fmd-blue-light;
+  //     color: $color-white-pure;
+  //   }
+  //   .text {
+  //     color: $color-fmd-blue-dark;
+  //     font-size: $size-xs;
+  //     padding-left: $size-xxs/2;
+  //     padding-right: $size-xxs/2;
+  //   }
+  // }
   //end FMD variation
 }

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -12,17 +12,25 @@
 
   <section class="splash splash--tall grid_separator">
     <div class="grid_container grid_padded--xl">
+      <div class="grid_row grid_wrap--l">	
+        <div class="col_12">	
+          <h1 class="splash__headline">	
+            Texas Tribune members	
+            <br />	
+            support our&nbsp;	
+            <span class="rotate-words">	
+              <span>journalism.</span>	
+              <span>events.</span>	
+              <span>community.</span>	
+              <span>mission.</span>	
+            </span>	
+          </h1>	
+        </div>	
+      </div>
       <div class="splash__actions grid_row grid_wrap--l">
         <div class="col_8">
-          <h1 class="splash__headline">
-            #TexanSince 2009 &mdash; and we‘re just <nobr>getting started.</nobr>
-          </h1>
-          <p class="splash__description grid_separator">Texas Tribune members invest in our nonprofit newsroom because they believe credible, nonpartisan journalism makes for a better, smarter Texas. This Fall Member Drive, help us rally 400 new members as we embark on another decade of public service journalism.</p>
-          <div class="splash--buttons">
-              <a class="button button--yellow" href="#join-today" ga-event-category="donations" ga-event-action="membership-intent" ga-event-label="support landing">Join us</a>
-              <span class="text">or</span>
-              <a class="button button--yellow" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Ftrib.it%2FGj0&amp;text=%23ISupportTexasTribune%20because...%20%5BTELL%20THE%20WORLD%20WHY%20HERE!%5D%20%20" ga-event-category="donations" ga-event-action="share" ga-event-label="support landing" target="_blank">Spread the word</a>
-          </div>
+            <p class="splash__description grid_separator">Do you value credible, nonpartisan, public-interest journalism?</p>	          
+            <a class="button button--yellow grid_separator" href="#join-today" ga-event-category="donations" ga-event-action="membership-intent" ga-event-label="support landing">Show Your Support</a>
         </div>
       </div>
     </div>

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'includes/thermometer.html' %}
-
   <section class="splash splash--tall grid_separator">
     <div class="grid_container grid_padded--xl">
       <div class="splash__actions grid_row grid_wrap--l">


### PR DESCRIPTION
#### What's this PR do?
Reverts support landing back to pre-FMD settings (header image + copy, thermometer)

#### Why are we doing this? How does it help us?
FMD is over.

#### How should this be manually tested?
- Visit support.texastribune.org/donate
- Make sure you're seeing the navy header image (instead of the light colored one)
- Make sure text is rotating again
- Make sure jump link from the header to the checkout form is still working

#### How should this change be communicated to end users?
I'll tell Sarah 

#### Are there any smells or added technical debt to note?
No 

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/13064186/todos/2063727561

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
