### PR TITLE
Allow leading dollar signs in amounts

### DIFF
--- a/app.py
+++ b/app.py
@@ -343,20 +343,23 @@ def add_donation(form=None, customer=None, donation_type=None):
     return True
 
 
-def do_charge_or_show_errors(form, template, bundles, function, donation_type):
+def do_charge_or_show_errors(form_data, template, bundles, function, donation_type):
     app.logger.debug("----Creating Stripe customer...")
 
-    email = request.form["stripeEmail"]
-    installment_period = request.form["installment_period"]
-    amount = request.form["amount"]
+    email = form_data["stripeEmail"]
+    installment_period = form_data["installment_period"]
+    amount = form_data["amount"]
+    stripe_token = form_data["stripeToken"]
 
     try:
-        customer = stripe.Customer.create(email=email, card=request.form["stripeToken"])
+        customer = stripe.Customer.create(email=email, card=stripe_token)
     except stripe.error.CardError as e:
         body = e.json_body
         err = body.get("error", {})
         message = err.get("message", "")
-        form_data = request.form.to_dict()
+        # at this point, amount has been converted to a float
+        # bring it back to a string for the rehydration of the form
+        form_data["amount"] = str(form_data["amount"])
         del form_data["stripeToken"]
 
         return render_template(
@@ -368,7 +371,7 @@ def do_charge_or_show_errors(form, template, bundles, function, donation_type):
             form_data=form_data,
         )
     app.logger.info(f"Customer id: {customer.id}")
-    function(customer=customer, form=clean(form.data), donation_type=donation_type)
+    function(customer=customer, form=clean(form_data), donation_type=donation_type)
     gtm = {
         "event_value": amount,
         "event_label": "once" if installment_period == "None" else installment_period,
@@ -380,6 +383,12 @@ def validate_form(FormType, bundles, template, function=add_donation.delay):
     app.logger.info(pformat(request.form))
 
     form = FormType(request.form)
+    # use form.data instead of request.form from here on out
+    # because it includes all filters applied by WTF Forms
+    form_data = form.data
+    form_errors = form.errors
+    email = form_data["stripeEmail"]
+
     if FormType is DonateForm:
         donation_type = "membership"
     elif FormType is CircleForm:
@@ -391,22 +400,20 @@ def validate_form(FormType, bundles, template, function=add_donation.delay):
     else:
         raise Exception("Unrecognized form type")
 
-    email = request.form["stripeEmail"]
-
     if not validate_email(email):
         message = "There was an issue saving your email address."
         return render_template(
             "error.html", message=message, bundles=get_bundles("old")
         )
     if not form.validate():
-        app.logger.error(f"Form validation errors: {form.errors}")
+        app.logger.error(f"Form validation errors: {form_errors}")
         message = "There was an issue saving your donation information."
         return render_template(
             "error.html", message=message, bundles=get_bundles("old")
         )
 
     return do_charge_or_show_errors(
-        form=form,
+        form_data=form_data,
         bundles=bundles,
         template=template,
         function=function,

--- a/app.py
+++ b/app.py
@@ -343,7 +343,7 @@ def add_donation(form=None, customer=None, donation_type=None):
     return True
 
 
-def do_charge_or_show_errors(template, bundles, function, donation_type):
+def do_charge_or_show_errors(form, template, bundles, function, donation_type):
     app.logger.debug("----Creating Stripe customer...")
 
     email = request.form["stripeEmail"]
@@ -368,7 +368,7 @@ def do_charge_or_show_errors(template, bundles, function, donation_type):
             form_data=form_data,
         )
     app.logger.info(f"Customer id: {customer.id}")
-    function(customer=customer, form=clean(request.form), donation_type=donation_type)
+    function(customer=customer, form=clean(form.data), donation_type=donation_type)
     gtm = {
         "event_value": amount,
         "event_label": "once" if installment_period == "None" else installment_period,
@@ -406,6 +406,7 @@ def validate_form(FormType, bundles, template, function=add_donation.delay):
         )
 
     return do_charge_or_show_errors(
+        form=form,
         bundles=bundles,
         template=template,
         function=function,

--- a/forms.py
+++ b/forms.py
@@ -10,7 +10,27 @@ from wtforms.fields import (
 from wtforms.fields.html5 import EmailField
 
 
-def strip_filter(value):
+def validate_amount(form, field):
+    value = field.data
+    if value is None:
+        raise validators.ValidationError("Invalid amount")
+    if value < 1:
+        raise validators.ValidationError("Amount is less than 1")
+
+
+def format_amount(value):
+    if value.startswith("$"):
+        value_to_convert = value[1:]
+    else:
+        value_to_convert = value
+    try:
+        float(value_to_convert)
+        return float(value_to_convert)
+    except ValueError:
+        return None
+
+
+def strip_whitespace(value):
     if value is not None and hasattr(value, "strip"):
         return value.strip()
     return value
@@ -20,7 +40,7 @@ class BaseForm(FlaskForm):
     class Meta:
         def bind_field(self, form, unbound_field, options):
             filters = unbound_field.kwargs.get("filters", [])
-            filters.append(strip_filter)
+            filters.append(strip_whitespace)
             return unbound_field.bind(form=form, filters=filters, **options)
 
     first_name = StringField(
@@ -29,12 +49,13 @@ class BaseForm(FlaskForm):
     last_name = StringField(
         u"Last name", [validators.required(message="Your last name is required.")]
     )
-    amount = DecimalField(
+    amount = StringField(
         u"Amount",
-        [
+        validators=[
             validators.required(message="Please choose a donation amount."),
-            validators.NumberRange(min=1),
+            validate_amount,
         ],
+        filters=[format_amount],
     )
     stripeEmail = EmailField(
         "Email address", [validators.DataRequired(), validators.Email()]

--- a/forms.py
+++ b/forms.py
@@ -23,12 +23,9 @@ def validate_amount(form, field):
 # then convert to a float
 def format_amount(value):
     if value.startswith("$"):
-        value_to_convert = value[1:]
-    else:
-        value_to_convert = value
+        value = value[1:]
     try:
-        float(value_to_convert)
-        return float(value_to_convert)
+        return float(value)
     except ValueError:
         return None
 

--- a/forms.py
+++ b/forms.py
@@ -14,7 +14,7 @@ from wtforms.fields.html5 import EmailField
 def validate_amount(form, field):
     value = field.data
     if value is None:
-        raise validators.ValidationError("Invalid amount")
+        raise validators.ValidationError("Non-numeric amount provided")
     if value < 1:
         raise validators.ValidationError("Amount is less than 1")
 

--- a/forms.py
+++ b/forms.py
@@ -10,6 +10,7 @@ from wtforms.fields import (
 from wtforms.fields.html5 import EmailField
 
 
+# amount must be $1 or higher
 def validate_amount(form, field):
     value = field.data
     if value is None:
@@ -18,6 +19,8 @@ def validate_amount(form, field):
         raise validators.ValidationError("Amount is less than 1")
 
 
+# if value starts with a dollar sign, remove it
+# then convert to a float
 def format_amount(value):
     if value.startswith("$"):
         value_to_convert = value[1:]

--- a/static/js/src/connected-elements/PayFees.vue
+++ b/static/js/src/connected-elements/PayFees.vue
@@ -40,7 +40,13 @@ export default {
         key: 'amount',
       });
 
-      if (!isValidDonationAmount(amount)) return false;
+      if (!isValidDonationAmount(amount)) {
+        return false;
+      }
+
+      if (amount.charAt(0) === '$') {
+        amount = amount.substring(1);
+      }
 
       amount = parseFloat(amount.trim());
 

--- a/static/js/src/utils/validators.js
+++ b/static/js/src/utils/validators.js
@@ -23,8 +23,16 @@ export const isEmptyOrZip = value => {
 };
 
 export const isValidDonationAmount = value => {
+  let valueToCheck;
+
+  if (value.charAt(0) === '$') {
+    valueToCheck = value.substring(1);
+  } else {
+    valueToCheck = value;
+  }
+
   const isValid = validate(
-    { value: value.trim() },
+    { value: valueToCheck.trim() },
     { value: { numericality: { greaterThanOrEqualTo: 1 } } }
   );
   return typeof isValid === 'undefined';


### PR DESCRIPTION
#### What's this PR do?
Allows `$88` and `88` to both be valid amounts on the donate form.

#### Why are we doing this? How does it help us?
Sarah G. request.

#### How should this be manually tested?
+ `make`
+ `make restart`
+ Confirm you can successfully donate with and without a leading dollar sign on `/donate`
+ To be sure, confirm you can successfully donate on `/circle` and `/business` too

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
I originally wanted to handle this all client side. But it was a strange and confusing UX to remove characters after someone finished typing an amount. I then thought about maintaining some sort of background data store with data that's formatted differently than what you actually see on the form (in other words, with dollar signs stripped out). But that proved nearly impossible given we literally submit the form and the data it contains (as opposed to use it as a vehicle to construct an API payload like in UMP).

Thus, I simply updated the client-side validator to allow leading dollar signs, then updated the back-end logic to remove the dollar sign (if it exists), validate the amount and then convert it to an integer.

@x110dc If you could please confirm I didn't butcher anything too much on the Python side, I'd be grateful.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/2178926818

#### Have you done the following, if applicable:
* [x] Added automated tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked for security implications?
* [ ] Updated the documentation/wiki?