### PR TITLE
Add teal with more contrast on white bg

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sentry/integrations": "^5.6.0",
     "@sentry/webpack-plugin": "^1.6.2",
     "@texastribune/queso-tools": "^2.1.0",
-    "@texastribune/queso-ui": "^5.1.0",
+    "@texastribune/queso-ui": "^8.0.0",
     "auth0-js": "^9.10.2",
     "axios": "^0.19.0",
     "babel-loader": "^8.0.0",

--- a/static/sass/1-settings/_colors.scss
+++ b/static/sass/1-settings/_colors.scss
@@ -2,7 +2,7 @@
 $color-yellow-tribune: #ffc200;
 $color-blue-light: #a1d2df;
 $color-blue-dark: #223136;
-$color-teal-gray: #539bae;
+$color-teal-gray: #348094;
 $color-red: #ff6047;
 $color-sand: #f2ede2;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,10 +790,10 @@
     svgo "^1.2.2"
     svgstore "^3.0.0-2"
 
-"@texastribune/queso-ui@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@texastribune/queso-ui/-/queso-ui-5.1.0.tgz#e28f8c212f881b66b824d967660419a638ea7374"
-  integrity sha512-/s3BC4YgBirOeEsShBC6HrFXJh3v1vfvKneFrWcR7TDvGfARpuSenAYOIOqDnnF2MN4tsD7zaXBo0+JfR6o5Ng==
+"@texastribune/queso-ui@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@texastribune/queso-ui/-/queso-ui-8.0.0.tgz#11bf92826c95b20ad5827e29a7d45f0c7960b0c3"
+  integrity sha512-TzsLcmzS/kmI8ohRZ+KccjDhbcTuQnIFKLWmTwp2D3RBJp13M8v+b4h2lNpBTQBbBERfXaTdKzTWphbP3i2VsA==
   dependencies:
     normalize.css "^8.0.1"
     sass-mq "^5.0.0"


### PR DESCRIPTION
#### What's this PR do?
Adds the new latest and greatest, AA compliant, shade of teal

#### Why are we doing this? How does it help us?

Better a11y

#### How should this be manually tested?

We don't really use teal too much, but you can see the new shade on the names of the quotes, the link:hover underline color, and the portal submit button.


#### How should this change be communicated to end users?

Shouldn't

#### Are there any smells or added technical debt to note?

We're bumping up a few versions of queso, but I checked version 6 and 7 and I don't see how anything in this repo would be visually changed by those updates.


#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [x] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *Run a gray audit on this repo. We got clearance in /texastribune to bring all smallcaps--light and subtitle gray to AA compliance. There are few places on the form pages and portal that could benefit from that. I didn't lump that into here because I didn't want to hold getting 🧀 8.0 up.*
* [ ] *Darken the`$color-error`design token in queso and import that patch for the error states of the forms and portal fields*

