### PR TITLE
Darken grays flagged in a11y audits

### DIFF
--- a/static/js/src/entry/account/routes/home/components/LinkEmail.vue
+++ b/static/js/src/entry/account/routes/home/components/LinkEmail.vue
@@ -24,7 +24,7 @@
         </div>
         <div class="has-b-btm-marg">
           <slot name="text" :linked-emails="linkedEmails | formatLinkedEmails">
-            <p class="t-size-xs has-text-gray">
+            <p class="t-size-xs has-text-gray-dark">
               You're seeing donations from:
               <strong>{{ linkedEmails | formatLinkedEmails }}</strong
               >. You may have donated with a different email address. Enter

--- a/static/js/src/entry/account/routes/payments/components/Detail.vue
+++ b/static/js/src/entry/account/routes/payments/components/Detail.vue
@@ -2,7 +2,9 @@
   <section class="c-detail-box">
     <div class="has-xxl-btm-marg"><payment-list :payments="data" /></div>
 
-    <p class="t-size-xs t-links-underlined has-text-gray has-xxxl-btm-marg">
+    <p
+      class="t-size-xs t-links-underlined has-text-gray-dark has-xxxl-btm-marg"
+    >
       Note: Donation history does not include event sponsorships or ticket
       purchases. To receive a {{ lastYear }} tax receipt with this information,
       please contact

--- a/static/sass/5-typography/_typography.scss
+++ b/static/sass/5-typography/_typography.scss
@@ -23,7 +23,7 @@
 
   // Byline
   &--light {
-    color: $color-gray-medium;
+    color: $color-gray-dark;
     font-size: $size-xs;
     font-weight: 400;
     letter-spacing: .05em;
@@ -75,7 +75,7 @@
 // Examples: Grayed text below smallcaps, comment policy
 .subtext {
   @extend %link--blue;
-  color: $color-gray-medium;
+  color: $color-gray-dark;
   font-size: $size-xs;
   font-weight: 400;
   padding: 0;

--- a/static/sass/6-components/_quotes.scss
+++ b/static/sass/6-components/_quotes.scss
@@ -3,10 +3,10 @@
 
   &__quote {
     @include font-setting('secondary');
-    color: $color-gray-medium;
+    color: $color-gray-dark;
     font-size: $size-b;
   }
-  
+
   &__attribution {
     color: $color-teal-gray;
     font-size: $size-xs;

--- a/static/sass/ds/6-components/_side-nav.scss
+++ b/static/sass/ds/6-components/_side-nav.scss
@@ -12,7 +12,7 @@
     font-weight: bold;
 
     &.is-active {
-      color: $color-gray-medium;
+      color: $color-gray-dark;
       font-weight: normal;
     }
   }


### PR DESCRIPTION
#### What's this PR do?

Update grays used in various places to be a darker hex value.

#### Why are we doing this? How does it help us?

We recently discovered that sometimes our use of gray in text is too light to be WCAG AA compliant

#### How should this be manually tested?

- make backing
- make
- yarn run dev
- make restart
- View a few pages like the forms on /donate and /business
- Login to the portal
- See detailed checks below:


@AndrewGibson27 - Use your axe tool to scan any page for color contrast bugs.
- The splash (hero) title seems to get flagged, but that's not addressed here. Also I feel like it's actually fine 🤷‍♀
- The stripe card input placeholder is also flagged, but not so much controlled by us from what I understand

@emilyyount - View the following changes and make sure they feel okay to you on the design front:
- The quotes on /donate
- The active text in the UMP left nav
- The notation text on the donation history page

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Nah

#### What are the relevant tickets?

off-sprint

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [x] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
