### PR TITLE
Update fee language to include range (for AmEx)

### DIFF
--- a/static/js/src/connected-elements/PayFees.vue
+++ b/static/js/src/connected-elements/PayFees.vue
@@ -51,9 +51,19 @@ export default {
       amount = parseFloat(amount.trim());
 
       const total = (amount + 0.3) / (1 - 0.022);
-      const fee = Math.floor((total - amount) * 100) / 100;
+      const amexTotal = amount / (1 - 0.035);
 
-      return `$${fee.toFixed(2)}`;
+      const fee = Math.floor((total - amount) * 100) / 100;
+      const amexFee = Math.floor((amexTotal - amount) * 100) / 100;
+
+      const lowerFee = Math.min(fee, amexFee);
+      const higherFee = Math.max(fee, amexFee);
+
+      if (lowerFee === higherFee) {
+        return `$${lowerFee.toFixed(2)}`;
+      }
+
+      return `between $${lowerFee.toFixed(2)} and $${higherFee.toFixed(2)}`;
     },
 
     installmentPeriod() {


### PR DESCRIPTION
#### What's this PR do?
Changes the fee language to say "between [lower fee] and [higher fee]" instead of just a single amount.

#### Why are we doing this? How does it help us?
Because Stripe has a different AmEx fee for nonprofits. And because Evan L. wants to start tracking gross amounts in SalesForce instead of nets.

#### How should this be manually tested?
`make`
`make restart`
Visit `/donate` and change the form amount a few times. Confirm the fee language has a range that updates as you type. The lower fee should always be the first number. Confirm you can donate successfully.

#### How should this change be communicated to end users?
This is the communication.

#### Are there any smells or added technical debt to note?
This is the easiest solution but maybe not the permanent one. As Daniel and I discussed over email, doing anything more would require some non-trivial UI updates to the donation process that seem a little scary to do without an Emily Y. or Amanda around.

#### What are the relevant tickets?
None.

#### Have you done the following, if applicable:
* [ ] Added automated tests?
* [ ] Tested manually on mobile?
* [ ] Checked BrowserStack?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for security implications?
* [ ] Updated the documentation/wiki?