### PR TITLE
Robots.txt Add disallow for another account endpoint

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /account/*
+Disallow: /account


### PR DESCRIPTION
#### What's this PR do?
Disallow directive added for `/account`

#### Why are we doing this? How does it help us?
Bots hitting `/account` which results in an error

#### How should this be manually tested?
Check if the `Disallow: /account`  line is included in robots.txt 
We'll see if the error goes away in Google Search Console &/or Alexa, but we can't truly control bots, just ask them nicely to stop

#### How should this change be communicated to end users?
Not needed

#### Are there any smells or added technical debt to note?
Nah

#### What are the relevant tickets?
[Add /account to Donations robots.txt](https://3.basecamp.com/3098728/buckets/736178/todos/2491237469#__recording_2542145848)

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***
N/A

#### TODOs / next steps:

* [ ] I'll follow up and see if we're no longer  seeing robots hitting `/account`