### PR TITLE
Run npm install to sync lock file with latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3355,7 +3355,8 @@
       "dependencies": {
         "acorn": {
           "version": "6.4.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
           "dev": true
         },
         "debug": {


### PR DESCRIPTION
#### What's this PR do?

This is the output of running `npm install` on master

#### Why are we doing this? How does it help us?

The hope is that every time you need to run npm install, you're not committing an unintentional change.

#### How should this be manually tested?
On master:
run `make` to get into the app and then `npm install`. `git status` should show a change in package.lock.json. Undo those changes to clean your staged commits.

In this branch:
Run `npm install` again. Confirm that package.lock.json remains unchanged.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

This may introduce a security warning about acorn in the GitHub interface. If that's the case we'll push up another PR with a manual `npm audit fix` and deal with that in each subsequent PR.

#### What are the relevant tickets?

N/A - Just trying to prevent weird future commits

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [x] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *Determine if this creates a new security warning and run `npm audit fix` if so*
