### PR TITLE
Remove font face observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       }
     },
     "@texastribune/queso-ui": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-8.3.5.tgz",
-      "integrity": "sha512-r6/1PcxfB5Cq3cmxdt6bpKdaILVtV1NgOj1M8gCRv8/TIAHjdf9zWneU7eBoBeIEGxQC8ksppIALIbUvYxPARA==",
+      "version": "8.4.0-0",
+      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-8.4.0-0.tgz",
+      "integrity": "sha512-XaSGOPbI6taexwRc1KZ3M19NITAptrl8gqDX52oT/nHx46rdNkK/BvYkU/DQYts7ei4d/XYT074AVJPJAmkmfQ==",
       "requires": {
         "normalize.css": "^8.0.1",
         "sass-mq": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3905,11 +3905,6 @@
         }
       }
     },
-    "fontfaceobserver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
-      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@sentry/integrations": "^5.6.0",
     "@sentry/webpack-plugin": "^1.6.2",
     "@texastribune/queso-tools": "^2.1.0",
-    "@texastribune/queso-ui": "^8.3.5",
+    "@texastribune/queso-ui": "^8.4.0-0",
     "auth0-js": "^9.10.2",
     "axios": "^0.19.0",
     "babel-loader": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "es6-promise": "^4.2.4",
     "fast-async": "7",
     "file-loader": "^1.1.11",
-    "fontfaceobserver": "^2.1.0",
     "glob-watcher": "^5.0.3",
     "jsonwebtoken": "^8.5.1",
     "jspdf": "^1.5.3",

--- a/static/sass/_ds-toolbox-base.scss
+++ b/static/sass/_ds-toolbox-base.scss
@@ -7,6 +7,9 @@
 // mixins and functions (no actual CSS output)
 @import "@texastribune/queso-ui/assets/scss/2-tools/all";
 
+// fonts
+@import "@texastribune/queso-ui/assets/scss/4-elements/font-families";
+
 // t-size helper for sizing fonts
 @import "@texastribune/queso-ui/assets/scss/5-typography/t-helpers";
 @import "@texastribune/queso-ui/assets/scss/5-typography/t-size";

--- a/templates/account.html
+++ b/templates/account.html
@@ -23,7 +23,7 @@
       }
     </style>
 
-    {% include "includes/font_load.html" %}
+    {% include "includes/polyfills.html" %}
   </head>
 
   <body>

--- a/templates/includes/polyfills.html
+++ b/templates/includes/polyfills.html
@@ -1,0 +1,9 @@
+<script>
+  /**
+    Promises
+    https://github.com/bramstein/fontfaceobserver
+  */
+  (function(){'use strict';var f,g=[];function l(a){g.push(a);1==g.length&&f()}function m(){for(;g.length;)g[0](),g.shift()}f=function(){setTimeout(m)};function n(a){this.a=p;this.b=void 0;this.f=[];var b=this;try{a(function(a){q(b,a)},function(a){r(b,a)})}catch(c){r(b,c)}}var p=2;function t(a){return new n(function(b,c){c(a)})}function u(a){return new n(function(b){b(a)})}function q(a,b){if(a.a==p){if(b==a)throw new TypeError;var c=!1;try{var d=b&&b.then;if(null!=b&&"object"==typeof b&&"function"==typeof d){d.call(b,function(b){c||q(a,b);c=!0},function(b){c||r(a,b);c=!0});return}}catch(e){c||r(a,e);return}a.a=0;a.b=b;v(a)}}
+  function r(a,b){if(a.a==p){if(b==a)throw new TypeError;a.a=1;a.b=b;v(a)}}function v(a){l(function(){if(a.a!=p)for(;a.f.length;){var b=a.f.shift(),c=b[0],d=b[1],e=b[2],b=b[3];try{0==a.a?"function"==typeof c?e(c.call(void 0,a.b)):e(a.b):1==a.a&&("function"==typeof d?e(d.call(void 0,a.b)):b(a.b))}catch(h){b(h)}}})}n.prototype.g=function(a){return this.c(void 0,a)};n.prototype.c=function(a,b){var c=this;return new n(function(d,e){c.f.push([a,b,d,e]);v(c)})};
+  function w(a){return new n(function(b,c){function d(c){return function(d){h[c]=d;e+=1;e==a.length&&b(h)}}var e=0,h=[];0==a.length&&b(h);for(var k=0;k<a.length;k+=1)u(a[k]).c(d(k),c)})}function x(a){return new n(function(b,c){for(var d=0;d<a.length;d+=1)u(a[d]).c(b,c)})};window.Promise||(window.Promise=n,window.Promise.resolve=u,window.Promise.reject=t,window.Promise.race=x,window.Promise.all=w,window.Promise.prototype.then=n.prototype.c,window.Promise.prototype["catch"]=n.prototype.g);}());
+</script>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -45,15 +45,6 @@
 </script>
 
 {% block adwords_conversion_code %}{% endblock %}
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open Sans:400,700']
-      }
-    });
-  </script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/templates/new_layout.html
+++ b/templates/new_layout.html
@@ -42,16 +42,6 @@
     </script>
 
     {% block adwords_conversion_code %}{% endblock %}
-
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-    <script>
-      WebFont.load({
-        google: {
-          families: ['Open Sans:400,700', 'PT Serif:400,700']
-        }
-      });
-    </script>
-
     {% block head_scripts %}{% endblock %}
   </head>
   <body>


### PR DESCRIPTION
#### What's this PR do?
Remove font face observer and just let font-display do the work

#### Why are we doing this? How does it help us?
One fewer script, one fewer dependency etc. Now that more browsers honor `font-display: swap`, we can just rely on that.

The latest queso also fixes the color inheritance on "Reset your password"
#### How should this be manually tested?

`make` `npm install` `make restart`

Ensure fonts load in main app and /account

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Unrelated to this I noticed Google's recaptcha script loads Roboto for us, which is annoying, but that's where that gfont request is coming from FYI.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/2480337638

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [x] Checked BrowserStack? *( )*
* [x] Checked for performance implications? *( )*
* [x] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
