### PR TITLE
add clack notifications on failed charge

### DIFF
--- a/batch-tmp.py
+++ b/batch-tmp.py
@@ -6,7 +6,7 @@ from pytz import timezone
 
 import celery
 import redis
-from charges import amount_to_charge, charge
+from charges import amount_to_charge, charge, ChargeException
 from npsp import Opportunity
 from util import send_email
 
@@ -100,7 +100,11 @@ def charge_cards():
         log.it(
             f"---- Charging ${amount} to {opportunity.stripe_customer} ({opportunity.name})"
         )
-        charge(opportunity)
+        try:
+            charge(opportunity)
+        except ChargeException:
+            # TODO should we alert slack? Did not because we had no notifications here before
+            pass
 
     log.send()
 

--- a/batch.py
+++ b/batch.py
@@ -6,7 +6,7 @@ from pytz import timezone
 
 import celery
 import redis
-from charges import amount_to_charge, charge
+from charges import amount_to_charge, charge, ChargeException
 from npsp import Opportunity
 from util import send_email
 
@@ -100,7 +100,11 @@ def charge_cards():
         log.it(
             f"---- Charging ${amount} to {opportunity.stripe_customer} ({opportunity.name})"
         )
-        charge(opportunity)
+        try:
+            charge(opportunity)
+        except ChargeException:
+            # TODO should we alert slack? Did not because we had no notifications here before
+            pass
 
     log.send()
 

--- a/charges.py
+++ b/charges.py
@@ -12,6 +12,22 @@ stripe.api_key = STRIPE_KEYS["secret_key"]
 TWOPLACES = Decimal(10) ** -2  # same as Decimal('0.01')
 
 
+class ChargeException(Exception):
+    def __init__(self, opportunity, message):
+        super().__init__(message)
+        self.opportunity = opportunity
+        self.message = message
+
+    def send_slack_notification(self):
+        send_slack_message(
+            {
+                "channel": "#stripe",
+                "text": f"Charge failed for {self.opportunity.name} [{self.message}]",
+                "icon_emoji": ":x:",
+            }
+        )
+
+
 def amount_to_charge(opportunity):
     """
     Determine the amount to charge. This depends on whether the payer agreed
@@ -79,21 +95,19 @@ def charge(opportunity):
                     "icon_emoji": ":x:",
                 }
             )
-        return
+
+        raise ChargeException(opportunity, "card error")
 
     except stripe.error.InvalidRequestError as e:
         logging.error(f"Problem: {e}")
-        # TODO should we raise this?
-        return
+        raise ChargeException(opportunity, "invalid request")
     except Exception as e:
         logging.error(f"Problem: {e}")
-        # TODO should we raise this?
-        return
+        raise ChargeException(opportunity, "unknown error")
 
     if card_charge.status != "succeeded":
         logging.error("Charge failed. Check Stripe logs.")
-        # TODO should we raise this?
-        return
+        raise ChargeException(opportunity, "charge failed")
 
     opportunity.stripe_card = card_charge.source.id
     opportunity.stripe_transaction_id = card_charge.id


### PR DESCRIPTION
#### What's this PR do?
Adds slack notifications on charge errors and removes success notification in #donations on error.

For charges where there were no notification before I did not add new ones because I don't know if that was done for privacy reasons, etc.

#### Why are we doing this? How does it help us?
Better understanding via slack what happened with donations.

#### How should this be manually tested?
Check slack for notification of an invalid charge.

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
No

#### What are the relevant tickets?
Off-sprint

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
