### PR TITLE
Append temp message to all stripe errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,8 @@ from util import (
     clean,
     notify_slack,
     send_email_new_business_membership,
-    send_multiple_account_warning, send_slack_message,
+    send_multiple_account_warning,
+    send_slack_message,
 )
 from validate_email import validate_email
 from charges import charge, ChargeException
@@ -363,6 +364,8 @@ def do_charge_or_show_errors(form_data, template, bundles, function, donation_ty
         body = e.json_body
         err = body.get("error", {})
         message = err.get("message", "")
+        if message:
+            message = f"{message} Having issues making a donation? You can also <a href='https://www.paypal.me/texastribune'>give via PayPal here</a>."
         # at this point, amount has been converted to a float
         # bring it back to a string for the rehydration of the form
         form_data["amount"] = str(form_data["amount"])

--- a/app.py
+++ b/app.py
@@ -364,8 +364,8 @@ def do_charge_or_show_errors(form_data, template, bundles, function, donation_ty
         body = e.json_body
         err = body.get("error", {})
         message = err.get("message", "")
-        if message:
-            message = f"{message} Our apologies, we’re having some trouble processing your donation. You can <a href='https://www.paypal.me/texastribune'>give via PayPal here</a>."
+        # delete this once we hear back from stripe
+        message = f"{message} Having issues making a donation? You can also <a href='https://www.paypal.me/texastribune'>give via PayPal here</a>."
         # at this point, amount has been converted to a float
         # bring it back to a string for the rehydration of the form
         form_data["amount"] = str(form_data["amount"])

--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def do_charge_or_show_errors(form_data, template, bundles, function, donation_ty
         err = body.get("error", {})
         message = err.get("message", "")
         if message:
-            message = f"{message} Having issues making a donation? You can also <a href='https://www.paypal.me/texastribune'>give via PayPal here</a>."
+            message = f"{message} Our apologies, we’re having some trouble processing your donation. You can <a href='https://www.paypal.me/texastribune'>give via PayPal here</a>."
         # at this point, amount has been converted to a float
         # bring it back to a string for the rehydration of the form
         form_data["amount"] = str(form_data["amount"])

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -9,11 +9,12 @@
     <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
-          <!-- eslint-disable-next-line vue/no-v-html -->
+          <!-- eslint-disable -->
           <p
             class="form__error form__error--prominent"
             v-html="serverErrorMessage"
           ></p>
+          <!-- eslint-enable -->
         </div>
       </div>
     </div>

--- a/static/js/src/entry/business/TopForm.vue
+++ b/static/js/src/entry/business/TopForm.vue
@@ -9,9 +9,11 @@
     <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
-          <p class="form__error form__error--prominent">
-            {{ serverErrorMessage }}
-          </p>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <p
+            class="form__error form__error--prominent"
+            v-html="serverErrorMessage"
+          ></p>
         </div>
       </div>
     </div>

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -9,11 +9,12 @@
     <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
-          <!-- eslint-disable-next-line vue/no-v-html -->
+          <!-- eslint-disable -->
           <p
             class="form__error form__error--prominent"
             v-html="serverErrorMessage"
           ></p>
+          <!-- eslint-enable -->
         </div>
       </div>
     </div>

--- a/static/js/src/entry/circle/TopForm.vue
+++ b/static/js/src/entry/circle/TopForm.vue
@@ -9,9 +9,11 @@
     <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
       <div class="grid_row">
         <div class="col">
-          <p class="form__error form__error--prominent">
-            {{ serverErrorMessage }}
-          </p>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <p
+            class="form__error form__error--prominent"
+            v-html="serverErrorMessage"
+          ></p>
         </div>
       </div>
     </div>

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -194,7 +194,6 @@
 </template>
 
 <script>
-// eslint-disable-no-v-html
 import Hidden from '../../connected-elements/Hidden.vue';
 import LocalHidden from '../../local-elements/Hidden.vue';
 import Radios from '../../connected-elements/Radios.vue';

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -8,11 +8,12 @@
   >
     <div v-if="serverErrorMessage" class="grid_row grid_separator">
       <div class="col">
-        <!-- eslint-disable-next-line vue/no-v-html -->
+        <!-- eslint-disable -->
         <p
           class="form__error form__error--prominent"
           v-html="serverErrorMessage"
         ></p>
+        <!-- eslint-enable -->
       </div>
     </div>
 

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -8,9 +8,11 @@
   >
     <div v-if="serverErrorMessage" class="grid_row grid_separator">
       <div class="col">
-        <p class="form__error form__error--prominent">
-          {{ serverErrorMessage }}
-        </p>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <p
+          class="form__error form__error--prominent"
+          v-html="serverErrorMessage"
+        ></p>
       </div>
     </div>
 
@@ -192,6 +194,7 @@
 </template>
 
 <script>
+// eslint-disable-no-v-html
 import Hidden from '../../connected-elements/Hidden.vue';
 import LocalHidden from '../../local-elements/Hidden.vue';
 import Radios from '../../connected-elements/Radios.vue';

--- a/static/sass/6-components/_forms.scss
+++ b/static/sass/6-components/_forms.scss
@@ -66,6 +66,11 @@
     &--centered {
       text-align: center;
     }
+
+    a {
+      font-weight: bold;
+      color: inherit;
+    }
   }
 
   // generic label


### PR DESCRIPTION
#### What's this PR do?

see title

#### Why are we doing this? How does it help us?

just adds a string to the error message we get back from stripe

#### How should this be manually tested?

I tested cards from this section https://stripe.com/docs/testing#cards-responses

#### How should this change be communicated to end users?

Tell engineering channel

#### Are there any smells or added technical debt to note?
This is just temporary until we hear back from stripe

Should we be more specific about when we append the message? I wasn't sure how to do that but open to discussing that

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
