### PR TITLE
Fix minor lighthouse SEO warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       }
     },
     "@texastribune/queso-ui": {
-      "version": "9.4.1-0",
-      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-9.4.1-0.tgz",
-      "integrity": "sha512-yGXNh8Kbi+sbikmCbmgHM47Eom/qG3d4yM3newIjjfUA3CWnF03dZBXIktWF+tX8sHlveAiPATdZElv6P4me/Q==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-9.4.2.tgz",
+      "integrity": "sha512-04ontynYiTcPBWauAJePyzLeyIf4LrMVCO0ufPUC3zGt+qEbG78ioFtiF8+U9dFqiL+OSMlQcolQ9OeltqKMXA==",
       "requires": {
         "modern-normalize": "^0.6.0",
         "sass-mq": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       }
     },
     "@texastribune/queso-ui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-9.0.1.tgz",
-      "integrity": "sha512-BTI3yGQIj+QrQ+cv32vr/UsJnJBJkdSSmCL8zdM54tOUtYAM+kSnYfPGwEIuu8j3Ma8TV/O6Mfm3/YSdqcd2Cw==",
+      "version": "9.4.1-0",
+      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-9.4.1-0.tgz",
+      "integrity": "sha512-yGXNh8Kbi+sbikmCbmgHM47Eom/qG3d4yM3newIjjfUA3CWnF03dZBXIktWF+tX8sHlveAiPATdZElv6P4me/Q==",
       "requires": {
         "modern-normalize": "^0.6.0",
         "sass-mq": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@sentry/integrations": "^5.6.0",
     "@sentry/webpack-plugin": "^1.6.2",
     "@texastribune/queso-tools": "^2.1.0",
-    "@texastribune/queso-ui": "^9.4.1",
+    "@texastribune/queso-ui": "^9.4.2",
     "auth0-js": "^9.13.2",
     "axios": "^0.19.0",
     "babel-loader": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@sentry/integrations": "^5.6.0",
     "@sentry/webpack-plugin": "^1.6.2",
     "@texastribune/queso-tools": "^2.1.0",
-    "@texastribune/queso-ui": "^9.0.1",
+    "@texastribune/queso-ui": "^9.4.1",
     "auth0-js": "^9.13.2",
     "axios": "^0.19.0",
     "babel-loader": "^8.0.0",

--- a/static/sass/6-components/_footer.scss
+++ b/static/sass/6-components/_footer.scss
@@ -1,5 +1,7 @@
 // To be removed after this repo is set up to take the base ds-toolbox elements file
 .c-site-footer {
+  padding: $size-l $size-b $size-giant;
+
   &__links {
     list-style: none;
   }

--- a/static/sass/_ds-toolbox-base.scss
+++ b/static/sass/_ds-toolbox-base.scss
@@ -23,6 +23,7 @@
 
 // layout
 @import "@texastribune/queso-ui/assets/scss/7-layout/align";
+@import "@texastribune/queso-ui/assets/scss/7-layout/container";
 @import "@texastribune/queso-ui/assets/scss/7-layout/display";
 
 // utilities

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,105 +1,107 @@
 {% from "./includes/icon.html" import icon %}
 <footer>
-    <div id="site_footer" class="c-site-footer has-bg-black-off has-text-white t-size-xs">
-        <div class="grid_container grid_row">
-            <div class="col">
-                <span class="c-icon c-icon--yellow c-site-footer__logo has-giant-btm-marg" style="font-size: 4rem;">
-                    <svg aria-hidden="true" viewBox="0 0 139 121" version="1.1" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" stroke="none" stroke-width="1" fill="none"><path fill="#FFC200" d="M49.09.09l37.09 49.87 7.98-20.65 7.78 20.64 22.03 1.02-17.22 13.78 6.23 21.23L139 120.97V.09z"/><path fill="#D39811" d="M94.16 73.89L75.73 86.02l5.84-21.27-17.22-13.78 21.83-1.01L49.09.09v120.88H139l-26.02-34.99z"/><path fill="#FFC200" d="M.88.09L19.57 28.6v92.37h29.52V.09z"/></g></svg>
-                </span>
-                <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-                <ul class="c-site-footer__links">
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
-                    </li>
-                    <li class="has-tiny-btm-marg"><a href="https://texastribune.org" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">&copy; 2020 The Texas Tribune</a></li>
-                </ul>
-            </div>
-            <div id="footer-sections" class="col hide_until--s">
-                <h5 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xs-btm-marg">Topics</h5>
-                <ul class="c-site-footer__links">
-                    {% include "./includes/section_list_items.html" %}
-                </ul>
-            </div>
-            <div class="col">
-                <h5 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xs-btm-marg">Info</h5>
-                <ul class="c-site-footer__links">
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
-                    </li>
+  <div id="site_footer" class="c-site-footer c-site-footer--standard has-bg-black-off has-text-white t-size-xs">
+    <div class="l-container l-container--xl c-site-footer__inner c-site-footer__inner--standard">
+      <div class="c-site-footer__col c-site-footer__col--1">
+          <span class="c-icon c-icon--yellow c-site-footer__logo has-giant-btm-marg" style="font-size: 4rem;">
+              <svg aria-hidden="true" viewBox="0 0 139 121" version="1.1" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" stroke="none" stroke-width="1" fill="none"><path fill="#FFC200" d="M49.09.09l37.09 49.87 7.98-20.65 7.78 20.64 22.03 1.02-17.22 13.78 6.23 21.23L139 120.97V.09z"/><path fill="#D39811" d="M94.16 73.89L75.73 86.02l5.84-21.27-17.22-13.78 21.83-1.01L49.09.09v120.88H139l-26.02-34.99z"/><path fill="#FFC200" d="M.88.09L19.57 28.6v92.37h29.52V.09z"/></g></svg>
+          </span>
+          <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+              <li>
+                  <a href="https://www.texastribune.org/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
+              </li>
+              <li>
+                  <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
+              </li>
+              <li><a href="https://texastribune.org" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">&copy; 2020 The Texas Tribune</a></li>
+          </ul>
+      </div>
+      <div id="footer-sections" class="c-site-footer__col c-site-footer__col--2 is-hidden-until-bp-m">
+          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Topics</h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+              {% include "./includes/section_list_items.html" %}
+          </ul>
+      </div>
+      <div class="c-site-footer__col c-site-footer__col--3">
+          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Info</h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+              <li>
+                  <a href="https://www.texastribune.org/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
+              </li>
 
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential
-                            tip</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="https://www.texastribune.org/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
-                    </li>
-                </ul>
-            </div>
-            <div class="col">
-                <h5 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xs-btm-marg">Social Media</h5>
-                <ul class="c-site-footer__links">
-                    <li class="has-tiny-btm-marg">
-                        <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">{{ icon('facebook', align_base=True,  extra_classes='c-site-footer__icon') }}Facebook</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">{{ icon('twitter', align_base=True,  extra_classes='c-site-footer__icon') }}Twitter</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="http://youtube.com/user/thetexastribune" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">{{ icon('youtube', align_base=True,  extra_classes='c-site-footer__icon') }}YouTube</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">{{ icon('instagram', align_base=True,  extra_classes='c-site-footer__icon') }}Instagram</a>
-                    </li>
-                    <li class="has-tiny-btm-marg">
-                        <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">{{ icon('linkedin', align_base=True,  extra_classes='c-site-footer__icon') }}LinkedIn</a>
-                    </li>
-                    <li class="has-b-btm-marg">
-                        <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">{{ icon('reddit', align_base=True,  extra_classes='c-site-footer__icon') }}Reddit</a>
-                    </li>
-                    <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-                    <li class="has-tiny-btm-marg t-lh-s">
-                        <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">{{ icon('your-texas', align_base=True,  extra_classes='c-site-footer__icon') }}Join our Facebook Group, This Is Your Texas.</a>
-                    </li>
-                </ul>
-            </div>
-
-        </div>
+              <li>
+                  <a href="https://www.texastribune.org/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential
+                      tip</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
+              </li>
+              <li>
+                  <a href="https://www.texastribune.org/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
+              </li>
+          </ul>
+      </div>
+      <div class="c-site-footer__col c-site-footer__col--4">
+          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Social Media</h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+              <li>
+                  <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">{{ icon('facebook', align_base=True,  extra_classes='c-site-footer__icon') }}Facebook</a>
+              </li>
+              <li>
+                  <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">{{ icon('twitter', align_base=True,  extra_classes='c-site-footer__icon') }}Twitter</a>
+              </li>
+              <li>
+                  <a href="http://youtube.com/user/thetexastribune" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">{{ icon('youtube', align_base=True,  extra_classes='c-site-footer__icon') }}YouTube</a>
+              </li>
+              <li>
+                  <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">{{ icon('instagram', align_base=True,  extra_classes='c-site-footer__icon') }}Instagram</a>
+              </li>
+              <li>
+                  <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">{{ icon('linkedin', align_base=True,  extra_classes='c-site-footer__icon') }}LinkedIn</a>
+              </li>
+              <li>
+                  <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external has-xxs-btm-marg l-display-ib" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">{{ icon('reddit', align_base=True,  extra_classes='c-site-footer__icon') }}Reddit</a>
+              </li>
+              <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
+              <li class="has-tiny-btm-marg t-lh-s">
+                  <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">{{ icon('your-texas', align_base=True,  extra_classes='c-site-footer__icon') }}Join our Facebook Group, This Is Your Texas.</a>
+              </li>
+          </ul>
+      </div>
     </div>
+  </div>
 </footer>

--- a/templates/new_layout.html
+++ b/templates/new_layout.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="The Texas Tribune’s nonprofit newsroom membership and donations page.">
     <link rel="shortcut icon" type="image/x-icon" href="{{ url_for('static', filename='img/favicon.ico') }}">
 
     {% block og_meta %}


### PR DESCRIPTION
#### What's this PR do?

Pairs with https://github.com/texastribune/texastribune/pull/4051
Adds a new layout for our mobile footer

#### Why are we doing this? How does it help us?

Squashes some warnings in lighthouse

#### How should this be manually tested?

`make`
`npm install`
`npm run css:prod`
`make restart`

1. Check the footer on that main donate page. Confirm the footer looks relatively the same on desktop and breaks into 2 columns on mobile.
2. Check the footer the account page. Confirm it is unchanged.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

A little more CSS, but not significant

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/2761662828

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [x] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [x] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
