### PR TITLE
Improve charge error handling

### DIFF
--- a/batch-tmp.py
+++ b/batch-tmp.py
@@ -102,9 +102,9 @@ def charge_cards():
         )
         try:
             charge(opportunity)
-        except ChargeException:
-            # TODO should we alert slack? Did not because we had no notifications here before
-            pass
+        except ChargeException as e:
+            logging.info("Batch charge error")
+            e.send_slack_notification()
 
     log.send()
 

--- a/batch.py
+++ b/batch.py
@@ -102,9 +102,9 @@ def charge_cards():
         )
         try:
             charge(opportunity)
-        except ChargeException:
-            # TODO should we alert slack? Did not because we had no notifications here before
-            pass
+        except ChargeException as e:
+            logging.info("Batch charge error")
+            e.send_slack_notification()
 
     log.send()
 


### PR DESCRIPTION
#### What's this PR do?
Makes sure all errors during charges close the opportunity so they don't end up on wall. Sends slack messages for failed recurring donations.

#### Why are we doing this? How does it help us?
To help prevent failed donations from getting on wall and to better investigate errors going forward.

#### How should this be manually tested?
Make a donation that will fail to check that we get it in Slack.

#### How should this change be communicated to end users?
Notify SF people that errors reason will change slightly in SF from "unknown failure" to "card declined for unknown reason" if a card is declined and Stripe doesn't say why and just to "unknown failure" for everything else.

#### Are there any smells or added technical debt to note?
Still don't know why recurring donations may end up on wall, but that's another problem.

#### What are the relevant tickets?
Off-sprint

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*
