### PR TITLE
Fix CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+            version: 19.03.13
       - run: |
           docker info
           docker build -f Dockerfile -t texastribune/checkout:dev .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           password: $DOCKERHUB_TTCIRCLECI_PASSWORD
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
             version: 19.03.13
       - run: |
           docker info


### PR DESCRIPTION
#### What's this PR do?

Hopefully squashes an error we [keep](https://app.circleci.com/pipelines/github/texastribune/donations/210/workflows/13c08480-fc24-49a4-a59c-5a8aee52b66c/jobs/2134) [getting](https://app.circleci.com/pipelines/github/texastribune/donations/209/workflows/ecc81994-2280-4ec8-a3cf-ec2183469ee2/jobs/2132) in CircleCi

#### Why are we doing this? How does it help us?

[Sounds like this was a recent problem](https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364/32) with the way CircleCi assigns the default Docker version. The initial post date on that error thread sorta aligns with when we started seeing this.

#### How should this be manually tested?

I think [this](https://app.circleci.com/pipelines/github/texastribune/donations/212/workflows/82af52b3-aeb0-486c-b037-e2ac2009dbf7/jobs/2136) is a good indication of this working now.


#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

I am curious if there's anything docker-related to be concerned with. I can't say I fully understand the implications of designating a version, but that thread led me to believe we have to now.

#### What are the relevant tickets?

N/A, this should help with future ones.

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x] Added automated tests? *( I mean kinda)*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*


