### PR TITLE
use different image for better Python+Node interaction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM python:3.9
+#FROM python:3.9
+FROM nikolaik/python-nodejs:python3.9-nodejs12
 
 # This Dockerfile is intended for development. See Dockerfile.sample for something more
 # suitable for production.
 
-ENV NODE_VERSION=node_12.x
+#ENV NODE_VERSION=node_12.x
 ENV FLASK_DEBUG 1
 ENV NPM_CONFIG_LOGLEVEL warn
 
-# install Node and NPM
-RUN apt-get -yq update && \
-    apt-get -yq install apt-transport-https && \
-    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb https://deb.nodesource.com/$NODE_VERSION stretch main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get -yq update && \
-    apt-get -y install nodejs && \
-    rm -rf /var/lib/apt/lists/*
+## install Node and NPM
+#RUN apt-get -yq update && \
+#    apt-get -yq install apt-transport-https && \
+#    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+#    echo "deb https://deb.nodesource.com/$NODE_VERSION stretch main" > /etc/apt/sources.list.d/nodesource.list && \
+#    apt-get -yq update && \
+#    apt-get -y install nodejs && \
+#    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,10 @@
-#FROM python:3.9
 FROM nikolaik/python-nodejs:python3.9-nodejs12
 
 # This Dockerfile is intended for development. See Dockerfile.sample for something more
 # suitable for production.
 
-#ENV NODE_VERSION=node_12.x
 ENV FLASK_DEBUG 1
-ENV NPM_CONFIG_LOGLEVEL warn
-
-## install Node and NPM
-#RUN apt-get -yq update && \
-#    apt-get -yq install apt-transport-https && \
-#    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-#    echo "deb https://deb.nodesource.com/$NODE_VERSION stretch main" > /etc/apt/sources.list.d/nodesource.list && \
-#    apt-get -yq update && \
-#    apt-get -y install nodejs && \
-#    rm -rf /var/lib/apt/lists/*
+ENV NPM_CONFIG_LOGLEVEL warn   # is this used?
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM nikolaik/python-nodejs:python3.9-nodejs12
 # suitable for production.
 
 ENV FLASK_DEBUG 1
-ENV NPM_CONFIG_LOGLEVEL warn   # is this used?
+ENV NPM_CONFIG_LOGLEVEL warn
 
 WORKDIR /app
 


### PR DESCRIPTION
#### What's this PR do?

Changes the Dockerfile to use a different image

#### Why are we doing this? How does it help us?

Better handles Python+Node together.

#### How should this be manually tested?

- `make`
- `make restart` 
- Make sure frontend things happen and work as expected. 
- `make test`
- Make sure CI works. 

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

It relinquishes some control over the image, but the versions are pinned. 

#### What are the relevant tickets?

Request on wiki. 

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
