### PR TITLE
Business membership benefits update

### DIFF
--- a/static/js/src/entry/business/Benefits.vue
+++ b/static/js/src/entry/business/Benefits.vue
@@ -62,24 +62,6 @@
           display, logo badge to place on the business member's site, and social
           media graphic/copy to share with the member’s communities
         </li>
-        <li>
-          Opportunity to gift a Texas Tribune
-          <a href="/donate">Informed Membership</a> (value of $99/year).
-          Benefits include:
-          <ul>
-            <li>Official Texas Tribune member decal</li>
-            <li>
-              Inclusion in the distribution list for #MembersOnly, a monthly
-              Texas Tribune exclusive communication
-            </li>
-            <li>
-              Special perks at
-              <a href="https://festival.texastribune.org/"
-                >The Texas Tribune Festival</a
-              >
-            </li>
-          </ul>
-        </li>
       </ul>
     </div>
 
@@ -105,20 +87,6 @@
               Lone Star receives a total of three annually (value of $750)
             </li>
             <li>Big Tex receives a total of four annually (value of $1,000)</li>
-          </ul>
-        </li>
-        <li>
-          Opportunity to gift a Texas Tribune
-          <a href="/donate">Informed Membership</a>
-          <ul>
-            <li>
-              Lone Star can gift a total of three Informed Memberships (value of
-              $297/year)
-            </li>
-            <li>
-              Big Tex can gift a total of five Informed Memberships (value of
-              $495/year)
-            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
#### What's this PR do?

Removes individual membership benefit from the business membership page

#### Why are we doing this? How does it help us?

Request from April

#### How should this be manually tested?

Go to /business and confirm both instances of informed membership are gone

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

nope

#### What are the relevant tickets?
April left us a basecamp task here: https://3.basecamp.com/3098728/buckets/736178/todos/4343138928

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
