### PR TITLE
Add message about GivingTuesday (11/30/21)

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ Talisman(
 )
 
 limiter = Limiter(
-    app, key_func=get_remote_address, default_limits=["200 per day", "50 per hour"]
+    app, key_func=get_remote_address, default_limits=["4000 per day", "50 per hour"]
 )
 
 log_level = logging.getLevelName(LOG_LEVEL)

--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ Talisman(
 )
 
 limiter = Limiter(
-    app, key_func=get_remote_address, default_limits=["4000 per day", "50 per hour"]
+    app, key_func=get_remote_address, default_limits=["200 per day", "50 per hour"]
 )
 
 log_level = logging.getLevelName(LOG_LEVEL)

--- a/static/sass/donate.scss
+++ b/static/sass/donate.scss
@@ -20,6 +20,9 @@
 @import '6-components/smd';
 @import '6-components/thermometer';
 
+// temp for givingtuesday
+@import './ds/6-components/message';
+
 @import '7-utilities/all';
 
 // This doesn't quite fit anywhere

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -29,7 +29,7 @@
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
             <div class="c-message grid_separator has-text-gray-dark t-size-s">
-                <p>This <strong>#GivingTuesday</strong>, give to become a member, and you’ll help us unlock $30,000 in matching gifts from Blue Cross Blue Shield of Texas and Tribune readers Rosa McCormick and Eloise Dejoria.
+                <p>This <strong>#GivingTuesday</strong>, give to become a member, and you’ll help us unlock $30,000 in matching gifts from Blue Cross Blue Shield of Texas and Tribune readers Rosa McCormick and Eloise DeJoria.
                 </p>
             </div>
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -28,6 +28,10 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
+            <div class="c-message grid_separator has-text-gray-dark t-size-s">
+                <p>This <strong>#GivingTuesday</strong>, give to become a member, and you’ll help us unlock $30,000 in matching gifts from Blue Cross Blue Shield of Texas and Tribune readers Rosa McCormick and Eloise Dejoria.
+                </p>
+            </div>
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
#### What's this PR do?

Adds a promotional note about GivingTuesday

#### Why are we doing this? How does it help us?

Part of a membership campaign

#### How should this be manually tested?

`make` + `make restart` - See that there's a note above the form about GivingTuesday

#### How should this change be communicated to end users?

I'll let Kassie, our membership manager know

#### Are there any smells or added technical debt to note?

It's temporary. I'll create a PR to revert after this is merged.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/4378743182

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [x] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
