### PR TITLE
adding send notification when batch charge processing job begins

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -8,7 +8,7 @@ from pytz import timezone
 from charges import ChargeException, QuarantinedException, amount_to_charge, charge
 from config import ACCOUNTING_MAIL_RECIPIENT, LOG_LEVEL, REDIS_URL, TIMEZONE
 from npsp import Opportunity
-from util import send_email
+from util import send_email, notify_slack
 
 zone = timezone(TIMEZONE)
 
@@ -91,7 +91,9 @@ def charge_cards():
 
     log.it("---Processing charges...")
 
-    log.it(f"Found {len(opportunities)} opportunities available to process.")
+    opportunities_cnt = len(opportunities)
+    log.it(f"Found {opportunities_cnt} opportunities available to process.")
+    notify_slack(text=f"Processing {opportunities_cnt} reoccuring donations")
 
     for opportunity in opportunities:
         if not opportunity.stripe_customer:

--- a/batch.py
+++ b/batch.py
@@ -91,9 +91,9 @@ def charge_cards():
 
     log.it("---Processing charges...")
 
-    opportunities_cnt = len(opportunities)
-    log.it(f"Found {opportunities_cnt} opportunities available to process.")
-    notify_slack(text=f"Processing {opportunities_cnt} reoccuring donations")
+    processing_msg = f"Found {len(opportunities)} opportunities available to process."
+    log.it(processing_msg)
+    notify_slack(text=processing_msg)
 
     for opportunity in opportunities:
         if not opportunity.stripe_customer:

--- a/util.py
+++ b/util.py
@@ -44,18 +44,24 @@ def construct_slack_message(contact=None, opportunity=None, rdo=None, account=No
     return message
 
 
-def notify_slack(contact=None, opportunity=None, rdo=None, account=None):
+def notify_slack(contact=None, opportunity=None, rdo=None, account=None, text=None):
     """
     Send a notification about a donation to Slack.
     """
 
-    text = construct_slack_message(
-        contact=contact, opportunity=opportunity, rdo=rdo, account=account
-    )
-    username = rdo.lead_source if rdo else opportunity.lead_source
+    # if needing to send a simpler slack message (i.e. job start/stop, processing count, etc.) pass in as text var
+    if not text:
+        text = construct_slack_message(
+            contact=contact, opportunity=opportunity, rdo=rdo, account=account
+        )
     message = {"text": text, "channel": SLACK_CHANNEL, "icon_emoji": ":moneybag:"}
 
-    send_slack_message(message, username=username)
+    if rdo or opportunity:
+        send_slack_message(
+            message, username=rdo.lead_source if rdo else opportunity.lead_source
+        )
+    else:
+        send_slack_message(message)
 
 
 def send_slack_message(message=None, username="moneybot"):


### PR DESCRIPTION
* updating notify_slack func to accept a simple text message
* adding call to notify_slack with simple message after some existing logging

#### What's this PR do?
Adds some functionality to send simpler slack notifications and sends a slack notification at the beginning of reoccurring charges processing.

#### Why are we doing this? How does it help us?
Recently an update involving celerybeat caused this batch processing job to fail quietly. While much of the processing is being logged as seen in the code, we're adding a small slack notification to confirm nightly that the job is still running as expected.

#### How should this be manually tested?
Good question. To the best of my knowledge, we'll just need to keep an eye on the nightly job and make sure it sends off the slack notification as expected.

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
I'm re-working the notify_slack func, so that's worth taking a close look at. It would take more work, but we could also add a counter to send a slack notification like "33 of 33 Donations Processed". One more thing... I used the wording "donations" instead of "opportunities". Let me know if that wording needs to stay consistent.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/4347915712

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] after deployed, follow up with next few nights worth of batch jobs
