### PR TITLE
Update copyright year in footers to be dynamic

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,22 +1,30 @@
-{% extends "layout.html" %}
-{% block title %}
-  {{ super() }}
-{% endblock %}
-{% block extra_script %}
-  {{ super() }}
-{% endblock %}
-
-{% block content %}
-{{ super() }}
+{% extends "layout.html" %} {% block title %} {{ super() }} {% endblock %} {%
+block extra_script %} {{ super() }} {% endblock %} {% block content %} {{
+super() }}
 <div class="main grid_container--m prose grid_padded--xl">
   <div class="grid_row">
     <figure class="image_default">
-      <img src="https://static.texastribune.org/media/marketing/tt-404_sorry.png" />
+      <img
+        src="https://static.texastribune.org/media/marketing/tt-404_sorry.png"
+      />
     </figure>
   </div>
   <h2>{{ message }}</h2>
-  <p>If you're trying to become a member or make a donation, you can go to <a href="/donate">our membership and donation page</a> for more info on how to support us or contact us at <a href="mailto:membership@texastribune.org">membership@texastribune.org</a>.</p>
-  <p>If you're having trouble signing up for The Blast, please email <a href="mailto:blast@texastribune.org">blast@texastribune.org</a>.</p>
-  <p>Visit <a href="https://www.texastribune.org/">The Texas Tribune homepage</a> to read and explore our content.</p>
+  <p>
+    If you're trying to become a member or make a donation, you can go to
+    <a href="/donate">our membership and donation page</a> for more info on how
+    to support us or contact us at
+    <a href="mailto:membership@texastribune.org">membership@texastribune.org</a
+    >.
+  </p>
+  <p>
+    If you're having trouble signing up for The Blast, please email
+    <a href="mailto:blast@texastribune.org">blast@texastribune.org</a>.
+  </p>
+  <p>
+    Visit
+    <a href="https://www.texastribune.org/">The Texas Tribune homepage</a> to
+    read and explore our content.
+  </p>
 </div>
 {% endblock %}

--- a/templates/includes/copyright_year.html
+++ b/templates/includes/copyright_year.html
@@ -1,0 +1,8 @@
+<span id="copyright-year"></span>
+<script>
+  /** Update copyright year with current year */
+  'use strict';
+  var currentYear = new Date().getFullYear();
+  var el = document.getElementById('copyright-year');
+  el.textContent = currentYear;
+</script>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,106 +1,324 @@
 {% from "./includes/icon.html" import icon %}
 <footer>
-  <div id="site_footer" class="c-site-footer c-site-footer--standard has-bg-black-off has-text-white t-size-xs">
-    <div class="l-container l-container--xl c-site-footer__inner c-site-footer__inner--standard">
+  <div
+    id="site_footer"
+    class="c-site-footer c-site-footer--standard has-bg-black-off has-text-white t-size-xs"
+  >
+    <div
+      class="l-container l-container--xl c-site-footer__inner c-site-footer__inner--standard"
+    >
       <div class="c-site-footer__col c-site-footer__col--1">
-          <span class="c-icon c-icon--yellow c-site-footer__logo has-giant-btm-marg" style="font-size: 4rem;">
-            <svg aria-hidden="true"><use xlink:href="#bug"></use></svg>
-          </span>
-          <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-          <ul class="c-site-footer__links c-site-footer__links--standard">
-              <li>
-                  <a href="https://www.texastribune.org/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
-              </li>
-              <li>
-                  <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
-              </li>
-              <li><a href="https://texastribune.org" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">&copy; 2021 The Texas Tribune</a></li>
-          </ul>
+        <span
+          class="c-icon c-icon--yellow c-site-footer__logo has-giant-btm-marg"
+          style="font-size: 4rem"
+        >
+          <svg aria-hidden="true"><use xlink:href="#bug"></use></svg>
+        </span>
+        <div
+          class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg"
+          aria-hidden="true"
+        ></div>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a
+              href="https://www.texastribune.org/contact/"
+              title="Contact Us"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="contact us"
+              >Contact Us</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://mediakit.texastribune.org/"
+              title="Advertise"
+              class="advertise"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="advertise"
+              >Advertise</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://texastribune.org"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="copyright"
+              >&copy; {% include "./includes/copyright_year.html" %} The Texas
+              Tribune</a
+            >
+          </li>
+        </ul>
       </div>
-      <div id="footer-sections" class="c-site-footer__col c-site-footer__col--2 is-hidden-until-bp-m">
-          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Topics</h2>
-          <ul class="c-site-footer__links c-site-footer__links--standard">
-              {% include "./includes/section_list_items.html" %}
-          </ul>
+      <div
+        id="footer-sections"
+        class="c-site-footer__col c-site-footer__col--2 is-hidden-until-bp-m"
+      >
+        <h2
+          class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+        >
+          Topics
+        </h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          {% include "./includes/section_list_items.html" %}
+        </ul>
       </div>
       <div class="c-site-footer__col c-site-footer__col--3">
-          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Info</h2>
-          <ul class="c-site-footer__links c-site-footer__links--standard">
-              <li>
-                  <a href="https://www.texastribune.org/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
-              </li>
+        <h2
+          class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+        >
+          Info
+        </h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a
+              href="https://www.texastribune.org/about/"
+              title="About Us"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="about us"
+              >About Us</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/staff/"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="our staff"
+              >Our Staff</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/jobs/"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="jobs"
+              >Jobs</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/support-us/donors-and-members/"
+              title="Who Funds Us?"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="who funds us"
+              >Who Funds Us?</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/texas-tribune-strategic-plan/"
+              title="Strategic Plan"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="strategic plan"
+              >Strategic Plan</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/republishing-guidelines/"
+              title="Republishing Guidelines"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="republishing guidelines"
+              >Republishing Guidelines</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/ethics/"
+              title="Code of Ethics"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="code of ethics"
+              >Code of Ethics</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/terms-of-service/"
+              title="Terms of Service"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="terms of service"
+              >Terms of Service</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/privacy-policy/"
+              title="Privacy Policy"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="privacy policy"
+              >Privacy Policy</a
+            >
+          </li>
 
-              <li>
-                  <a href="https://www.texastribune.org/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential
-                      tip</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
-              </li>
-              <li>
-                  <a href="https://www.texastribune.org/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
-              </li>
-          </ul>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/tips/"
+              title="Send a Tip"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="send us a confidential tip"
+              >Send us a confidential tip</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/corrections/"
+              title="Corrections"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="corrections"
+              >Corrections</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/feeds/"
+              title="Feeds"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="feeds"
+              >Feeds</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/about/subscribe/"
+              title="Newsletters"
+              ga-event-category="subscribe intent"
+              ga-event-action="footer link"
+              >Newsletters</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/audio/"
+              title="Audio"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="audio"
+              >Audio</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.texastribune.org/video/"
+              title="Video"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="video"
+              >Video</a
+            >
+          </li>
+        </ul>
       </div>
       <div class="c-site-footer__col c-site-footer__col--4">
-          <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Social Media</h2>
-          <ul class="c-site-footer__links c-site-footer__links--standard">
-              <li>
-                  <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">{{ icon('facebook', align_base=True,  extra_classes='c-site-footer__icon') }}Facebook</a>
-              </li>
-              <li>
-                  <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">{{ icon('twitter', align_base=True,  extra_classes='c-site-footer__icon') }}Twitter</a>
-              </li>
-              <li>
-                  <a href="http://youtube.com/user/thetexastribune" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">{{ icon('youtube', align_base=True,  extra_classes='c-site-footer__icon') }}YouTube</a>
-              </li>
-              <li>
-                  <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">{{ icon('instagram', align_base=True,  extra_classes='c-site-footer__icon') }}Instagram</a>
-              </li>
-              <li>
-                  <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">{{ icon('linkedin', align_base=True,  extra_classes='c-site-footer__icon') }}LinkedIn</a>
-              </li>
-              <li>
-                  <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external has-xxs-btm-marg l-display-ib" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">{{ icon('reddit', align_base=True,  extra_classes='c-site-footer__icon') }}Reddit</a>
-              </li>
-              <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-              <li class="has-tiny-btm-marg t-lh-s">
-                  <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">{{ icon('your-texas', align_base=True,  extra_classes='c-site-footer__icon') }}Join our Facebook Group, This Is Your Texas.</a>
-              </li>
-          </ul>
+        <h2
+          class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+        >
+          Social Media
+        </h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a
+              href="http://facebook.com/texastribune"
+              title="Facebook"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="facebook"
+              >{{ icon('facebook', align_base=True,
+              extra_classes='c-site-footer__icon') }}Facebook</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://twitter.com/texastribune"
+              title="Twitter"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="twitter"
+              >{{ icon('twitter', align_base=True,
+              extra_classes='c-site-footer__icon') }}Twitter</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://youtube.com/user/thetexastribune"
+              title="YouTube"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="youtube"
+              >{{ icon('youtube', align_base=True,
+              extra_classes='c-site-footer__icon') }}YouTube</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://instagram.com/texas_tribune"
+              title="Instagram"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="instagram"
+              >{{ icon('instagram', align_base=True,
+              extra_classes='c-site-footer__icon') }}Instagram</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://www.linkedin.com/company/texas-tribune"
+              title="LinkedIn"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="linkedin"
+              >{{ icon('linkedin', align_base=True,
+              extra_classes='c-site-footer__icon') }}LinkedIn</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.reddit.com/user/texastribune"
+              title="Reddit"
+              class="external has-xxs-btm-marg l-display-ib"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="reddit"
+              >{{ icon('reddit', align_base=True,
+              extra_classes='c-site-footer__icon') }}Reddit</a
+            >
+          </li>
+          <div
+            class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg"
+            aria-hidden="true"
+          ></div>
+          <li class="has-tiny-btm-marg t-lh-s">
+            <a
+              href="https://www.facebook.com/groups/thisisyourtexas/"
+              title="This is Your Texas"
+              class="external"
+              ga-event-category="navigation"
+              ga-event-action="footer link click"
+              ga-event-label="this is your texas"
+              >{{ icon('your-texas', align_base=True,
+              extra_classes='c-site-footer__icon') }}Join our Facebook Group,
+              This Is Your Texas.</a
+            >
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -58,7 +58,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <footer class="footer grid_padding grid_row grid_wrap--l">
     <nav class="col_3 grid_separator--s">
       <ul>
-        <li class="footer__copyright">© 2021 <a href="//www.texastribune.org/" class="unlink">The Texas Tribune</a></li>
+        <li class="footer__copyright">© {% include "./includes/copyright_year.html" %} <a href="//www.texastribune.org/" class="unlink">The Texas Tribune</a></li>
       </ul>
     </nav>
     <nav class="col_9 hide_until--m">


### PR DESCRIPTION
#### What's this PR do?

Updates the copyright year on the donation page and 404 page to automatically update based on the current year.

#### Why are we doing this? How does it help us?

Save us from manually updating the copyright year in footers.

#### How should this be manually tested?

Run the donations project locally. When viewing the page in the browser, the footer of the main page should read, "© 2022 The Texas Tribune".

Visit a non-existent page to view the 404 page. Eg. localhost/sdfsdf As above, "© 2022 The Texas Tribune" should be visible in the footer.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/4480830461

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
