### PR TITLE
Fix "failed to send email" for batch logs take 2

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -39,7 +39,7 @@ class Log(object):
         """
         Send the assembled log out as an email.
         """
-        body = "\n".join(self.log)
+        body = "\n".join(self.log.encode("utf-8"))
         recipient = ACCOUNTING_MAIL_RECIPIENT
         subject = "Batch run"
         send_email(body=body, recipient=recipient, subject=subject)

--- a/batch.py
+++ b/batch.py
@@ -39,7 +39,7 @@ class Log(object):
         """
         Send the assembled log out as an email.
         """
-        body = "\n".join(self.log).encode("utf-8")
+        body = "\n".join(self.log)
         recipient = ACCOUNTING_MAIL_RECIPIENT
         subject = "Batch run"
         send_email(body=body, recipient=recipient, subject=subject)


### PR DESCRIPTION
Changes the approach for texastribune/donations#842

The encoding I added stripped the line breaks and made the email difficult to interpret. This should keep the line breaks but also add the encoding to the names with non-ascii characters. h/t to @mailbackwards for this catch!