### PR TITLE
Fix "failed to send email" for batch logs take 3

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -123,7 +123,7 @@ def charge_cards():
             encoded_name = entry_name.encode("utf-8")
             logging.info(f"--- Test log: {encoded_name}")
         except:
-            logging.warn(f"Could not encode this name")
+            logging.warn("Could not encode this name")
 
     log.send()
 

--- a/batch.py
+++ b/batch.py
@@ -39,7 +39,7 @@ class Log(object):
         """
         Send the assembled log out as an email.
         """
-        body = "\n".join(self.log.encode("utf-8"))
+        body = "\n".join(self.log)
         recipient = ACCOUNTING_MAIL_RECIPIENT
         subject = "Batch run"
         send_email(body=body, recipient=recipient, subject=subject)
@@ -117,6 +117,13 @@ def charge_cards():
             logging.info(
                 "Failed to charge because Opportunity %s is quarantined", opportunity
             )
+        # todo: remove this after checking encoded output in papertrail
+        try:
+            entry_name = opportunity.name
+            encoded_name = entry_name.encode("utf-8")
+            logging.info(f"--- Test log: {encoded_name}")
+        except:
+            logging.warn(f"Could not encode {opportunity.name}")
 
     log.send()
 

--- a/batch.py
+++ b/batch.py
@@ -123,7 +123,7 @@ def charge_cards():
             encoded_name = entry_name.encode("utf-8")
             logging.info(f"--- Test log: {encoded_name}")
         except:
-            logging.warn(f"Could not encode {opportunity.name}")
+            logging.warn(f"Could not encode this name")
 
     log.send()
 


### PR DESCRIPTION
#### What's this PR do?

- Removes any encoding in the batch email log text
- Adds some logger.info output to test a theory to eventually fix the issue mentioned in https://github.com/texastribune/donations/pull/842

#### Why are we doing this? How does it help us?

The revenue team needs to be able to consistently view this email

#### How should this be manually tested?

N/A

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Yes, the extra logger.info should be removed eventually

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/4395801568

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
