### PR TITLE
Clarify readme: viewing the app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ celery beat --app app.celery &
 # gunicorn app:app --log-file=- --bind=0.0.0.0:5000 --access-logfile=-
 ```
 
-NOTE: Although `localhost:80` will display the index page for this app, you may need to use `local.texastribune.org/donate` in order to sign in to your account or otherwise interact with the account page.
+NOTE: If you are a Tribune engineer, you may need to use `local.texastribune.org/donate` in order to sign in to your account or otherwise interact with the account page.
 
 Running tests
 -------------

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ celery beat --app app.celery &
 # gunicorn app:app --log-file=- --bind=0.0.0.0:5000 --access-logfile=-
 ```
 
+NOTE: Although `localhost:80` will display the index page for this app, you may need to use `local.texastribune.org/donate` in order to sign in to your account or otherwise interact with the account page.
+
 Running tests
 -------------
 


### PR DESCRIPTION
#### What's this PR do?

Clarifies the Readme. Notes that if you're a Trib engineer, it might be best to use `local.texastribune.org/donate` when running the app locally.

#### Why are we doing this? How does it help us?

To prevent engineers/fellows on the Trib team from encountering unexpected behavior when running the app locally – especially if they're new to the team.

#### How should this be manually tested?

N/A

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

N/A

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/4547499294

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
