### PR TITLE
add listener for payout.paid and update opps with payout date

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ from forms import (
     CircleForm,
     DonateForm,
 )
-from npsp import RDO, Account, Affiliation, Contact, Opportunity
+from npsp import RDO, Account, Affiliation, Contact, Opportunity, SalesforceConnection
 from util import (
     clean,
     notify_slack,
@@ -710,6 +710,39 @@ def customer_source_updated(event):
     logging.info("card details updated")
 
 
+@celery.task(name="app.payout_paid")
+def payout_paid(event):
+
+    payout_id = event["data"]["object"]["id"]
+    # get the date of the payout
+    payout_date = event["data"]["object"]["arrival_date"]
+    # payout_date = stripe.Payout.retrieve(payout_id).arrival_date
+    payout_date = datetime.utcfromtimestamp(payout_date).strftime("%Y-%m-%d")
+
+    # get all of the charges in the payout
+    txn_list = []
+    txns = stripe.BalanceTransaction.list(payout=payout_id, type="charge", limit=100)
+    for txn in txns.auto_paging_iter():
+        txn_list.append(txn)
+
+    # format those ids for query
+    charge_ids = [t.source for t in txn_list]
+    charge_ids = ", ".join(["'{}'".format(value) for value in charge_ids])
+    query = (
+        f"SELECT Id FROM Opportunity WHERE Stripe_Transaction_ID__c IN ({charge_ids})"
+    )
+    logging.info(query)
+
+    # get the Opportunity Ids that go with those charges
+    sfc = SalesforceConnection()
+    opps_to_update = sfc.query(query)
+    opps_to_update = [o["Id"] for o in opps_to_update]
+
+    # set the payout date on those opportunities
+    response = sfc.update_payout_dates(opps_to_update, payout_date)
+    logging.debug(response)
+
+
 @celery.task(name="app.authorization_notification")
 def authorization_notification(payload):
 
@@ -844,6 +877,8 @@ def stripehook():
 
     if event.type == "customer.source.updated":
         customer_source_updated.delay(event)
+    if event.type == "payout.padi":
+        payout_paid.delay(event)
 
     # TODO change this to debug later
     app.logger.info(event)

--- a/app.py
+++ b/app.py
@@ -877,7 +877,7 @@ def stripehook():
 
     if event.type == "customer.source.updated":
         customer_source_updated.delay(event)
-    if event.type == "payout.padi":
+    if event.type == "payout.paid":
         payout_paid.delay(event)
 
     # TODO change this to debug later


### PR DESCRIPTION
#### What's this PR do?

It listens for payout events from Stripe and updates the corresponding Opportunities in Salesforce to record the payout date.

#### Why are we doing this? How does it help us?

Right now this process is being handled manually. 

#### How should this be manually tested?

- Run the server locally
- Use the Stripe CLI to listen for payout events and forward them to the local server
- Generate a payout event
- Make sure there's a matching transaction in your SF sandbox that can be updated
- This is all a bit of a pain to do

#### How should this change be communicated to end users?

Let those doing this process manually know to check that it all looks good and that they hopefully don't have to do this anymore.

#### Are there any smells or added technical debt to note?

In an effort to be efficient with API calls and not generate a call to the API for every single transaction the composite API was used. This reduces the API calls from 200+ to a single call. That meant not using the more general interface already present in the repo for interacting with SF. 

#### What are the relevant tickets?

Just a note in on a wiki page I think.

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
