### PR TITLE
bumping broker_connection_timeout to 60

### DIFF
--- a/app_celery.py
+++ b/app_celery.py
@@ -8,7 +8,7 @@ def make_celery(app):
         broker_pool_limit=1,
         broker_heartbeat=None,
         broker=app.config["CELERY_BROKER_URL"],
-        broker_connection_timeout=30,
+        broker_connection_timeout=60,
         result_backend=None,
         event_queue_expires=60,
         worker_prefetch_multiplier=1,


### PR DESCRIPTION
hoping to fix error 110 bug

#### What's this PR do?
Allows for a longer timeout window, hoping to curb random occurrences of Error 110.

#### Why are we doing this? How does it help us?
This Error 110 is causing donations to fail, at least 2 or 3 times a week. [Further info](https://www.cloudamqp.com/docs/celery.html) for what it's worth

#### How should this be manually tested?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
