### PR TITLE
Fix: Sentry frontend errors

### DIFF
--- a/static/js/src/entry/account/constants.js
+++ b/static/js/src/entry/account/constants.js
@@ -2,22 +2,16 @@ export const READ_WRITE_CREDIT_CARD_MESSAGE_KEY = 'readWriteCreditCardMessage';
 export const READ_WRITE_WELCOME_MESSAGE_KEY = 'readWriteWelcomeMessage';
 export const NON_STAFF_CONNECTION = 'Username-Password-Authentication';
 export const PORTAL_API_URL = `https://${process.env.PORTAL_API_DOMAIN}/v1/`;
-export const DONATE_URL = `/donate?installmentPeriod=monthly&amount=15&campaignId=${
-  process.env.PORTAL_CAMPAIGN_ID
-}#join-today`;
+export const DONATE_URL = `/donate?installmentPeriod=monthly&amount=15&campaignId=${process.env.PORTAL_CAMPAIGN_ID}#join-today`;
 export const CIRCLE_URL = '/circle';
 export const AUTH_DOMAIN = process.env.AUTH0_DOMAIN;
 export const AUTH_PORTAL_AUDIENCE = process.env.AUTH0_PORTAL_AUDIENCE;
 export const AUTH_PORTAL_CLIENT_ID = process.env.AUTH0_PORTAL_CLIENT_ID;
-export const AUTH_PORTAL_LOGOUT_COMPLETE_URL = `${
-  window.location.origin
-}/account/logged-out/`;
-export const AUTH_PORTAL_LOGIN_COMPLETE_URL = `${
-  window.location.origin
-}/account/logged-in/`;
+export const AUTH_PORTAL_LOGOUT_COMPLETE_URL = `${window.location.origin}/account/logged-out/`;
+export const AUTH_PORTAL_LOGIN_COMPLETE_URL = `${window.location.origin}/account/logged-in/`;
 export const TITLE_SUFFIX = ' | Your Texas Tribune Account';
-export const { SENTRY_DSN } = process.env;
-export const { SENTRY_ENVIRONMENT } = process.env;
+export const SENTRY_DSN = process.env.SENTRY_DSN;
+export const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
 export const ENABLE_SENTRY = process.env.ENABLE_SENTRY.toLowerCase() === 'true';
 export const GA_USER_PORTAL_NAV = {
   category: 'user portal navigation',

--- a/static/js/src/entry/account/constants.js
+++ b/static/js/src/entry/account/constants.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 export const READ_WRITE_CREDIT_CARD_MESSAGE_KEY = 'readWriteCreditCardMessage';
 export const READ_WRITE_WELCOME_MESSAGE_KEY = 'readWriteWelcomeMessage';
 export const NON_STAFF_CONNECTION = 'Username-Password-Authentication';


### PR DESCRIPTION
#### What's this PR do?

Ensures Sentry is successfully initialized in the frontend code of this app to ensure successful error reporting. Separate from this PR, the "allowed domains" setting in the Tribune's Sentry account has been adjusted to include several new domains.

#### Why are we doing this? How does it help us?

It was observed by the Tribune's engineering team that client side runtime errors were not being successfully reported to our Sentry account.

#### How should this be manually tested?

In order to ensure Sentry is working correctly it's necessary to throw a fake error in the Vue portion of the codebase. Do the following:

1) In your code editor, open: `static/js/src/entry/account/routes/account/Index.vue`
2) Replace the contents of the file with the following:
```
<template>
  <div>
    <user-nav-bar />

    <main class="has-bg-white-off">
      <div class="l-ump-container l-align-center-x">
        <div class="l-ump-grid">
          <div class="l-ump-grid__side is-hidden-until-bp-l">
            <button @click="throwError">THROW FAKE ERROR</button>
            <user-side-nav />
          </div>
          <div class="l-ump-grid__content has-bg-white"><router-view /></div>
        </div>
      </div>
    </main>

    <user-site-footer />

    <view-as-form />
  </div>
</template>

<script>
import routeMixin from '../mixin';

import userMixin from '../../store/user/mixin';

import UserSideNav from '../../nav/components/UserSideNav.vue';

const ViewAsForm = () =>
  import(
    /* webpackChunkName: "view-as-form" */ '../../view-as/containers/ViewAsFormContainer.vue'
  );

export default {
  name: 'Account',
  methods: {
    throwError() {
      throw new Error(
        'Fake error! Testing sentry error handling for PR review.'
      );
    },
  },
  components: { UserSideNav, ViewAsForm },

  mixins: [routeMixin, userMixin],
};
</script>

```
3) Run the app in JS/CSS watch mode as you normally would based on the readme instructions. Ie.:
```
make backing
make
make restart
```
4) Open `local.texastribune.org` in your browser and navigate to the accounts/ page.
5) Click on the "throw fake error" button on the page.
6) Check the Tribune's Sentry account to see if your error has appeared (this may take a minute).
7) If this is successful, it's also recommended that you refresh the app and spend a moment or two interacting with it to ensure everything else is working normally (ie. click around the page, perhaps make a test payment using one of Stripe's [fake payment cards](https://stripe.com/docs/testing)).

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Unless this PR is also tested on a staging site it won't be quite clear if the issue has been successfully solved in production until we start seeing client side production errors.

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/4697281642

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
