### PR TITLE
Add new tier of circle membership

### DIFF
--- a/static/js/src/Wall.vue
+++ b/static/js/src/Wall.vue
@@ -8,20 +8,22 @@
         :class="{ 'grid_separator--l': groupIndex !== memberGroups.length - 1 }"
         class="wall__group"
       >
-        <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
-        <slot name="subheading" :group="group"></slot>
-        <ul class="wall__list">
-          <li
-            v-for="(member, memberIndex) in group.members"
-            :key="memberIndex"
-            class="wall__item"
-          >
-            <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
-              ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
-            ></span>
-            <slot name="member" :member="member"></slot>
-          </li>
-        </ul>
+        <template v-if="group.members">
+          <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
+          <slot name="subheading" :group="group"></slot>
+          <ul class="wall__list">
+            <li
+              v-for="(member, memberIndex) in group.members"
+              :key="memberIndex"
+              class="wall__item"
+            >
+              <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
+                ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
+              ></span>
+              <slot name="member" :member="member"></slot>
+            </li>
+          </ul>
+        </template>
       </section>
     </div>
   </section>

--- a/static/js/src/Wall.vue
+++ b/static/js/src/Wall.vue
@@ -8,21 +8,20 @@
         :class="{ 'grid_separator--l': groupIndex !== memberGroups.length - 1 }"
         class="wall__group"
       >
-        <template v-if="group.members">
-          <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
-          <ul class="wall__list">
-            <li
-              v-for="(member, memberIndex) in group.members"
-              :key="memberIndex"
-              class="wall__item"
-            >
-              <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
-                ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
-              ></span>
-              <slot name="member" :member="member"></slot>
-            </li>
-          </ul>
-        </template>
+        <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
+        <slot name="subheading" :group="group"></slot>
+        <ul class="wall__list">
+          <li
+            v-for="(member, memberIndex) in group.members"
+            :key="memberIndex"
+            class="wall__item"
+          >
+            <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
+              ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
+            ></span>
+            <slot name="member" :member="member"></slot>
+          </li>
+        </ul>
       </section>
     </div>
   </section>

--- a/static/js/src/Wall.vue
+++ b/static/js/src/Wall.vue
@@ -8,19 +8,21 @@
         :class="{ 'grid_separator--l': groupIndex !== memberGroups.length - 1 }"
         class="wall__group"
       >
-        <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
-        <ul class="wall__list">
-          <li
-            v-for="(member, memberIndex) in group.members"
-            :key="memberIndex"
-            class="wall__item"
-          >
-            <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
-              ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
-            ></span>
-            <slot name="member" :member="member"></slot>
-          </li>
-        </ul>
+        <template v-if="group.members">
+          <h3 class="wall__heading grid_separator--s">{{ group.name }}</h3>
+          <ul class="wall__list">
+            <li
+              v-for="(member, memberIndex) in group.members"
+              :key="memberIndex"
+              class="wall__item"
+            >
+              <span class="wall__star c-icon c-icon--yellow c-icon--baseline"
+                ><svg aria-hidden="true"><use xlink:href="#star"></use></svg
+              ></span>
+              <slot name="member" :member="member"></slot>
+            </li>
+          </ul>
+        </template>
       </section>
     </div>
   </section>

--- a/static/js/src/entry/circle/CircleWall.vue
+++ b/static/js/src/entry/circle/CircleWall.vue
@@ -6,7 +6,7 @@
         <img src="./img/circle-logo.png" alt="Circle Membership logo" /></figure
     ></template>
     <template #subheading="{ group }">
-      <template v-if="group.name === 'Founders\' Circle'"
+      <template v-if="group.name === foundersLabel"
         ><p class="grid_separator--s">
           <em
             >In honor of our three founders: Ross Ramsey, Evan Smith and John
@@ -37,6 +37,7 @@ export default {
         'Leadership Circle',
         "Editor's Circle",
       ],
+      foundersLabel: "Founders' Circle",
     };
   },
 };

--- a/static/js/src/entry/circle/CircleWall.vue
+++ b/static/js/src/entry/circle/CircleWall.vue
@@ -25,6 +25,7 @@ export default {
         "Chairman's Circle",
         'Leadership Circle',
         "Editor's Circle",
+        "Founders' Circle",
       ],
     };
   },

--- a/static/js/src/entry/circle/CircleWall.vue
+++ b/static/js/src/entry/circle/CircleWall.vue
@@ -9,7 +9,7 @@
       <template v-if="group.name === 'Founders\' Circle'"
         ><p class="grid_separator--s">
           <em
-            >In honor of our three founders — Ross Ramsey, Evan Smith and John
+            >In honor of our three founders: Ross Ramsey, Evan Smith and John
             Thornton</em
           >
         </p></template

--- a/static/js/src/entry/circle/CircleWall.vue
+++ b/static/js/src/entry/circle/CircleWall.vue
@@ -5,6 +5,16 @@
       <figure class="wall__logo grid_separator--l" aria-hidden="true">
         <img src="./img/circle-logo.png" alt="Circle Membership logo" /></figure
     ></template>
+    <template #subheading="{ group }">
+      <template v-if="group.name === 'Founders\' Circle'"
+        ><p class="grid_separator--s">
+          <em
+            >In honor of our three founders — Ross Ramsey, Evan Smith and John
+            Thornton</em
+          >
+        </p></template
+      >
+    </template>
     <template #member="{ member }">
       <span class="wall__name">{{ member }}</span>
     </template>
@@ -22,10 +32,10 @@ export default {
   data() {
     return {
       orderedGroupNames: [
+        "Founders' Circle",
         "Chairman's Circle",
         'Leadership Circle',
         "Editor's Circle",
-        "Founders' Circle",
       ],
     };
   },

--- a/static/js/src/entry/circle/constants.js
+++ b/static/js/src/entry/circle/constants.js
@@ -39,6 +39,18 @@ export const CIRCLE_LEVELS = {
     installmentPeriod: 'yearly',
     amount: '5000',
   },
+  foundersMonthly: {
+    bucket: 'founders',
+    bucketFull: "Founders' Circle",
+    installmentPeriod: 'monthly',
+    amount: '834',
+  },
+  foundersYearly: {
+    bucket: 'founders',
+    bucketFull: "Founders' Circle",
+    installmentPeriod: 'yearly',
+    amount: '10000',
+  },
 };
 
 export const CIRCLE_FORM_STATE = {

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -76,6 +76,11 @@
         </div>
       </section>
 
+      <div class="grid_container--l grid_separator--xl">
+        <!-- where the wall component attaches -->
+        <div id="circle-wall"></div>
+      </div>
+
       <section class="grid_container--m section-padding grid_padded print__hide">
         <header>
           <div class="border--yellow_notch"></div>
@@ -112,10 +117,6 @@
         </div>
       </section>
 
-      <div class="grid_container--l grid_separator--xl">
-        <!-- where the wall component attaches -->
-        <div id="circle-wall"></div>
-      </div>
     </div>
   </main>
 {% endblock %}


### PR DESCRIPTION
#### What's this PR do?

- Adds founders' circle to the circle page
- Also prevents wall group headers from showing up if no one is in that group yet. That's the case for this one because it's new.

#### Why are we doing this? How does it help us?

This is a new tier set up in honor of the guys that started it all!

#### How should this be manually tested?

- Go to /cirlce
- Confirm that there's a new founders circle option in the form


#### How should this change be communicated to end users?

I'll let Irma and Terry know

#### Are there any smells or added technical debt to note?

Yes, there is a [smelly template hack](https://github.com/texastribune/donations/pull/900/files#diff-74bdbdc8f9f246de9d1aad04dce97b58d8ce6a869e6f01ee9083e7be6dc6785aR9) in that CircleWall.vue file. You won't see the template change on the page until there are members of the founders' circle. My reasoning is I didn't want to refactor the wall template too drastically for this one-off, but if we start to have more of these we'll want to make that part of the group data.

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwxXBBX2S2vWpUiC/recsYFF5cWlKyY1Jd?blocks=hide


#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
