### PR TITLE
Surface donation campaign ID in #stripe Slack message

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -269,6 +269,7 @@ def test__format_slack():
     opportunity.lead_source = "Stripe"
     opportunity.description = "The Texas Tribune Membership"
     opportunity.stripe_customer = "cus_78MqJSBejMN9gn"
+    opportunity.campaign_id = "111111111111111"
 
     rdo = RDO(sf_connection=sf)
     rdo.referral_id = "1234"
@@ -284,6 +285,7 @@ def test__format_slack():
     rdo.description = "Texas Tribune Circle Membership"
     rdo.agreed_to_pay_fees = True
     rdo.type = "Giving Circle"
+    rdo.campaign_id = "000000000000000"
 
     contact = Contact(sf_connection=sf)
     contact.email = "dcraigmile+test6@texastribune.org"
@@ -304,21 +306,23 @@ def test__format_slack():
     actual = construct_slack_message(
         account=account, rdo=rdo, opportunity=None, contact=None
     )
-    expected = "Acme Inc. pledged $100 [yearly] (Because I love the Trib!)"
+    expected = (
+        "Acme Inc. pledged $100 [yearly] (Because I love the Trib!) (000000000000000)"
+    )
 
     assert actual == expected
 
     actual = construct_slack_message(
         account=None, rdo=rdo, opportunity=None, contact=contact
     )
-    expected = "D C pledged $100 [yearly] (Because I love the Trib!)"
+    expected = "D C pledged $100 [yearly] (Because I love the Trib!) (000000000000000)"
 
     assert actual == expected
 
     actual = construct_slack_message(
         account=None, rdo=None, opportunity=opportunity, contact=contact
     )
-    expected = "D C pledged $9 [one-time] (Because I love the Trib!)"
+    expected = "D C pledged $9 [one-time] (Because I love the Trib!) (111111111111111)"
 
     assert actual == expected
 

--- a/util.py
+++ b/util.py
@@ -31,13 +31,21 @@ def construct_slack_message(contact=None, opportunity=None, rdo=None, account=No
         or getattr(opportunity, "encouraged_by", False)
         or ""
     )
+
+    campaign_id = (
+        getattr(rdo, "campaign_id", False)
+        or getattr(opportunity, "campaign_id", False)
+        or ""
+    )
+
     period = f"[{rdo.installment_period}]" if rdo else "[one-time]"
     amount = getattr(rdo, "amount", False) or getattr(opportunity, "amount", "")
     amount = float(amount)
     reason = f"({reason})" if reason else ""
+    campaign_id = f"({campaign_id})" if campaign_id else ""
     entity = account.name if account else contact.name
 
-    message = f"{entity} pledged ${amount:.0f} {period} {reason}"
+    message = f"{entity} pledged ${amount:.0f} {period} {reason} {campaign_id}"
 
     logging.info(message)
 


### PR DESCRIPTION
#### What's this PR do?

We send a message to the #stripe Slack channel when a donation successfully goes through. This PR modifies that message to include the campaign ID associated with the donation. This is done by getting the `campaign_id` attribute from the `rdo` or `opportunity` object. If there is not `campaign_id` in either of these objects, then we just use an empty string in place of it.

#### Why are we doing this? How does it help us?

This helps the membership team better monitor our donations to gauge which campaigns are doing well.

#### How should this be manually tested?

Our local development server throws a Salesforce error when we try to specify a campaign ID in the query parameters, with or without this code change:

```
ERROR root/npsp:267 - [ {
  "message" : "insufficient access rights on cross-reference id: 701460000007V3Q",
  "errorCode" : "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY",
  "fields" : [ ]
} ]
ERROR celery.app.trace/trace:265 - Task app.add_donation[c1ee1b97-fe38-446f-9ecc-dc73e9e8acfe] raised unexpected: SalesforceException('Expected 201 but got 400')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/app.py", line 343, in add_donation
    rdo = add_recurring_donation(
  File "/app/app.py", line 980, in add_recurring_donation
    rdo.save()
  File "/app/npsp.py", line 691, in save
    self.sf.save(self)
  File "/app/npsp.py", line 265, in save
    response = self.post(path=path, data=sf_object._format())
  File "/app/npsp.py", line 162, in post
    self.check_response(response=resp, expected_status=201)
  File "/app/npsp.py", line 127, in check_response
    raise e
npsp.SalesforceException: Expected 201 but got 400
```

So we can't really test this manually (as of now). But `test__format_slack` does work with the campaign ID included which is a good sign that it'll work in production. 

#### How should this change be communicated to end users?

Tell Kassie that we're surfacing the campaign ID.

#### Are there any smells or added technical debt to note?

No

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/4756665945

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *(Changed `test__format_slack` to include campaign ID in expected message format)*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] Deploy
* [ ] Test out some donations with a campaign ID query parameter on production.
