### PR TITLE
sping membership drive 2022 updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ from util import (
 )
 
 ZONE = timezone(TIMEZONE)
+USE_THERMOMETER = True
 
 if ENABLE_SENTRY:
     import sentry_sdk
@@ -494,6 +495,7 @@ def donate_form():
         bundles=bundles,
         stripe=app.config["STRIPE_KEYS"]["publishable_key"],
         recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
+        use_thermometer=USE_THERMOMETER,
     )
 
 

--- a/static/js/src/entry/donate/Thermometer.vue
+++ b/static/js/src/entry/donate/Thermometer.vue
@@ -43,7 +43,7 @@ export default {
 
   methods: {
     getSalesforceReport() {
-      const url = 'https://membership.texastribune.org/fmd2021.json';
+      const url = 'https://membership.texastribune.org/smd2022.json';
 
       axios
         .get(url)

--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 import RouteHandler from '../../RouteHandler.vue';
+import Thermometer from './Thermometer.vue';
 import TopForm from './TopForm.vue';
 import mergeValuesIntoStartState from '../../utils/merge-values-into-start-state';
 import sanitizeParams from '../../utils/sanitize-params';
@@ -91,6 +92,14 @@ function bindRouterEvents(router, routeHandler, store) {
 
     routeHandler.$mount('#app');
     topForm.$mount('#top-form');
+
+    // don't disply theremometer if the #thermometer div isn't included,
+    // based on the constant USE_THERMOMETER in app.py
+    const thermometerEl = document.getElementById('thermometer') || None;
+    if (thermometerEl) {
+      const thermometer = new Vue({ ...Thermometer, store });
+      thermometer.$mount(thermometerEl)
+    }
   });
 }
 

--- a/static/js/src/entry/donate/router.js
+++ b/static/js/src/entry/donate/router.js
@@ -95,7 +95,7 @@ function bindRouterEvents(router, routeHandler, store) {
 
     // don't disply theremometer if the #thermometer div isn't included,
     // based on the constant USE_THERMOMETER in app.py
-    const thermometerEl = document.getElementById('thermometer') || None;
+    const thermometerEl = document.getElementById('thermometer');
     if (thermometerEl) {
       const thermometer = new Vue({ ...Thermometer, store });
       thermometer.$mount(thermometerEl)

--- a/static/sass/donate.scss
+++ b/static/sass/donate.scss
@@ -20,6 +20,8 @@
 @import '6-components/smd';
 @import '6-components/thermometer';
 
+@import './ds/6-components/message';
+
 @import '7-utilities/all';
 
 // This doesn't quite fit anywhere

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -9,6 +9,10 @@
 {% endblock %}
 
 {% block content %}
+  {% if use_thermometer %}
+    {% include "includes/thermometer.html" %}
+  {% endif %}
+
   <section class="splash splash--tall grid_separator--l">
     <div class="grid_container grid_padded--xl">
       <div class="grid_row grid_wrap--l">
@@ -28,6 +32,11 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
+            <div class="c-message grid_separator has-text-gray-dark t-size-s">
+              <p>We’re looking for 400 new members this Spring Member Drive. Are you one of them? Donate now to join our growing member community.</p>
+              <br>
+              <p>And when you give monthly or yearly, you’ll help us unlock a $10K match from Jorge Baldor and Suzanne Deal Booth Cultural Trust. Double your impact today and help mission-driven journalism flourish in Texas.</p>
+            </div>
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
#### What's this PR do?
* reintroduces the pieces for the md thermometer
* adds a bool (USE_THERMOMETER) to switch on/off the thermometer
* some smd 2022-specific language
 
#### Why are we doing this? How does it help us?
Prep for spring md 2022 and makes it easier for us to turn on/off the thermometer piece in the future

#### How should this be manually tested?
make
make restart
ensure the thermometer pieces appear at the top of the page when visiting 'localhost/donate'
further, set USE_THERMOMETER in app.py to False and ensure the thermometer is now removed

#### How should this change be communicated to end users?
We'll coordinate with the membership team on this deploy.

#### Are there any smells or added technical debt to note?
Maybe there's a better location for the USE_THERMOMETER bool but the config.py file seemed higher level, so leaving in the app.py file made the most sense. Thoughts?

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwCUOttsruMqY7r7/recbxvR2usv8Ot8bo?blocks=hide
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwCUOttsruMqY7r7/recNvkptSQFa73uEC?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
