### PR TITLE
turn off thermometer and uncomment messaging area

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,7 @@ from util import (
 )
 
 ZONE = timezone(TIMEZONE)
-USE_THERMOMETER = True
+USE_THERMOMETER = False
 
 if ENABLE_SENTRY:
     import sentry_sdk

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -32,11 +32,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s">
-              <p>Help us secure $10,000 in a matching gift from Tito’s Handmade Vodka.</p>
-              <br>
-              <p>When you donate any amount by midnight Central time, Tito’s will double your gift dollar for dollar.</p>
-            </div>
+            <!-- <div class="c-message grid_separator has-text-gray-dark t-size-s">
+              <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div> -->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
for end of smd 22

#### What's this PR do?
Turns off the thermometer on the support page and removes the timely messaging block tied to membership drive.

#### Why are we doing this? How does it help us?
SMD 22 is over.

#### How should this be manually tested?
make
make restart
visit localhost/donate and ensure the thermometer and the messaging block are gone

#### How should this change be communicated to end users?
Don't think it needs to be, but we can announce in general if we need to.

#### Are there any smells or added technical debt to note?
Previously the scss for the messaging block had been removed when tearing down after a support event, but I'm leaving it in this time around so there's less to think about next md (and it seems relatively harmless and will be used again in the future). That said, happy to hear any counter thoughts.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwCUOttsruMqY7r7/rec2TKhmvv4Xrijqk?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
