### PR TITLE
Hotfix: Remove campaign text

### DIFF
--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -32,11 +32,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s link--blue">
-              <p>Support our long-term coverage from Uvalde and contribute to a coverage fund by June 30. Our goal is to raise $25,000 — and we can reach it, with your help.</p>
-              <br>
-              <p>Reader support for this fund so far also directly leveraged dollars for Uvaldeans in need: The Texas Tribune’s editor-in-chief pledged to match the first $10,000 toward this goal in the form of a gift to the <a href="https://www.communityfoundation.net/uvaldestrong/" target="_blank" rel="noopener">Uvalde Strong Fund</a>.</p>
-            </div>
+            <!-- <div class="c-message grid_separator has-text-gray-dark t-size-s">
+              <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div> -->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
Brings us back to 495b3fd04f2e6eb92f39b2ac1b8363b4ebf48ddc, before the Uvalde fundraiser began.

Removes combination of https://github.com/texastribune/donations/pull/935, 3ec61d0f1f6a5e254324153f2c54ea0666222af6, and 495b3fd04f2e6eb92f39b2ac1b8363b4ebf48ddc