### PR TITLE
Top nav updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1512,9 +1512,9 @@
       }
     },
     "@texastribune/queso-ui": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-10.3.0.tgz",
-      "integrity": "sha512-qQNNLW68cieFfCLy4aME5k0Hz7ekhMkG2UPjz1hdCLaH9QTnJh4nLRUI+sN5QYe9rOa08zZJ/rSN46nojVRMbg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@texastribune/queso-ui/-/queso-ui-10.3.1.tgz",
+      "integrity": "sha512-4KLy3HzdbKIdu52hWkFxKg/XZI5foFtOlwvMZFwtgJ79v6Af34MmE1lrExYALVmZiuRG6JIKoMgBUNR5azN97Q==",
       "requires": {
         "modern-normalize": "^1.0.0",
         "sass-mq": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@sentry/integrations": "^5.6.0",
     "@sentry/webpack-plugin": "^1.18.9",
     "@texastribune/queso-tools": "^2.3.1",
-    "@texastribune/queso-ui": "^10.3.0",
+    "@texastribune/queso-ui": "^10.3.1",
     "auth0-js": "^9.17.0",
     "axios": "^0.21.4",
     "babel-loader": "^8.2.3",

--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -13,6 +13,11 @@
           </a>
         </li>
         <li class="c-navbar__item is-hidden-until-bp-l">
+          <a href="https://www.texastribune.org/topics/texas-tribune-investigations/" class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated" ga-on="click" ga-event-category="navigation" ga-event-action="top nav click" ga-event-label="investigations">
+            <strong>Investigations</strong>
+          </a>
+        </li>
+        <li class="c-navbar__item is-hidden-until-bp-l">
           <a href="https://www.texastribune.org/about/subscribe/" class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"  ga-on="click" ga-event-category="subscribe intent" ga-event-action="top nav click" ga-event-label="not frontpage">
             <strong>Newsletters</strong>
           </a>


### PR DESCRIPTION
#### What's this PR do?

Add investigations link to the navbar
Bumps queso styles up to the latest version, but shouldn't have any visual changes

#### Why are we doing this? How does it help us?

Highlights a big part of what we do as an org

#### How should this be manually tested?

Confirm that the new investigations link appears in the top navbar and links out to https://www.texastribune.org/topics/texas-tribune-investigations/

#### How should this change be communicated to end users?

Note in #team-engineering

#### Are there any smells or added technical debt to note?

Nope!

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
