### PR TITLE
Added email disclaimer to support page by editing .../donate/TopForm.vue

### DIFF
--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -177,6 +177,10 @@
     </div>
 
     <p class="subtext">
+       By donating, you will receive member communications at the email address you provide.
+    </p>
+
+    <p class="subtext">
       This site is protected by reCAPTCHA and the Google
       <a href="https://policies.google.com/privacy">Privacy Policy</a> and
       <a href="https://policies.google.com/terms">Terms of Service</a> apply.


### PR DESCRIPTION
#### What's this PR do?
It adds the following line "By donating, you will receive member communications at the email address you provide." to Line 179 of ../donate/TopForm.vue. 

#### Why are we doing this? How does it help us?
We are doing this to indicate to people that by donating, they will receive member-related communications to the email address they provide.

#### How should this be manually tested?
The change should be visible before the Terms of Service phrase. It should look like this: 
"By donating, you will receive member communications at the email address you provide.
 This site is protected by reCAPTCHA and the Google and Terms of Service apply." 

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
N/A

#### What are the relevant tickets?
N/A

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ N/A] Added automated tests? *( )*
* [ N/A] Tested manually on mobile? *( )*
* [ N/A] Checked BrowserStack? *( )*
* [ N/A] Checked for performance implications? *( )*
* [ N/A] Checked accessibility? *( )*
* [ N/A] Checked for security implications? *( )*
* [N/A ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:
N/A