### PR TITLE
Restore donations page to pre-FMD and pre-festival state

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,7 @@ from util import (
 )
 
 ZONE = timezone(TIMEZONE)
-USE_THERMOMETER = True
+USE_THERMOMETER = False
 
 if ENABLE_SENTRY:
     import sentry_sdk

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-fmd22.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="At The Texas Tribune, members make public service journalism possible. Become a member today and donate to support the Tribune's nonprofit newsroom.">

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -41,9 +41,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-xs">
-              <p>Donate before 11:59 p.m. Central time on Sept. 25, and you’ll be entered to <a target="_blank" rel="noopener noreferrer" href="https://trib.it/getaway" class="has-text-gray-dark has-text-hover-black"><strong>win one of two stays in downtown Austin or historic Salado</strong></a> and dinner for two. Get an extra entry when you make a monthly gift.</p>
-            </div>
+            <!-- <div class="c-message grid_separator has-text-gray-dark t-size-s">
+              <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div> -->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>

--- a/templates/includes/benefits.html
+++ b/templates/includes/benefits.html
@@ -1,18 +1,3 @@
-<h4 class="grid_separator--s">TribFest is your ticket to the biggest politics and policy conversations in Texas — with a special experience just for Tribune members.</h4>
-<div class="prose grid_separator--l">
-  <p><a href="https://festival-platform.texastribune.org?promo=tt-donate-page&tr=true" target="_blank">The Texas Tribune Festival</a>, happening Sept. 22-24 in downtown Austin, is a favorite experience for Tribune members each year. Join us to hear from what will be 300+ thought leaders and decision makers from the worlds of politics, government, technology, media and beyond in a program designed to surprise and challenge you.</p>
-  <p>TribFest offers special perks to Tribune members who donate $35 or more a year:</p>
-  <ul class="list--bulleted grid_separator--l">
-    <li>Registration discount</li>
-    <li>Access to members-only experiences</li>
-    <li>Priority access at select venues</li>
-    <li>Invites to exclusive programming and events</li>
-    <li>Premium seating at opening and closing keynotes</li>
-    <li>And so much more!</li>
-  </ul>
-  <p>Donate to become a Texas Tribune member and enjoy special perks at TribFest when you give $35 or more a year. If you’re already a member, buy your ticket today to <a href="https://festival-platform.texastribune.org?promo=tt-donate-page&tr=true" target="_blank">claim your TribFest member experience</a>.</p>
-</div>
-
 <div class="border--yellow_notch"></div>
 <h2 id="benefits" class="grid_separator link--teal">Benefits by giving level</h2>
 


### PR DESCRIPTION
#### What's this PR do?
This PR removes the thermometer, FMD text, and Tribune Festival text. 

#### Why are we doing this? How does it help us?
We are doing this because both the FMD and Tribune Festival are completed. 

#### How should this be manually tested?
Ensure the thermometer, FMD text, and Tribune Festival text are NOT showing up on the donations page. 

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
N/A

#### What are the relevant tickets?
N/A

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ N/A] Added automated tests? *( )*
* [N/A ] Tested manually on mobile? *( )*
* [ N/A] Checked BrowserStack? *( )*
* [ N/A] Checked for performance implications? *( )*
* [N/A ] Checked accessibility? *( )*
* [ N/A] Checked for security implications? *( )*
* [ N/A] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ N/A] *your TODO here*
