### PR TITLE
Fixed Donation Fee Rounding Bug

### DIFF
--- a/static/js/all.js
+++ b/static/js/all.js
@@ -91,7 +91,7 @@ var payFeeAmount = function() {
     payFeeElement.text('');
   } else {
     var totalAmount = (goalAmount + .30) / (1 - 0.022);
-    var feeAmount = Math.floor((totalAmount - goalAmount) * 100) / 100;
+    var feeAmount = Math.round((totalAmount - goalAmount) * 100) / 100;
 
     payFeeElement.text('$' + feeAmount.toFixed(2));
   }

--- a/static/js/blast.js
+++ b/static/js/blast.js
@@ -35,7 +35,7 @@ var listen_for_installments = function() {
 var payFeeAmount = function() {
   var goalAmount = parseFloat($('input[name="amount"]:checked').val()),
       totalAmount = (goalAmount + .30) / (1 - 0.022);
-      feeAmount = Math.floor((totalAmount - goalAmount) * 100) / 100,
+      feeAmount = Math.round((totalAmount - goalAmount) * 100) / 100,
       payFeeElement = $('#pay-fee-amount span');
 
   payFeeElement.text('$' + feeAmount.toFixed(2));

--- a/static/js/src/connected-elements/PayFees.vue
+++ b/static/js/src/connected-elements/PayFees.vue
@@ -51,7 +51,7 @@ export default {
       amount = parseFloat(amount.trim());
 
       const total = (amount + 0.3) / (1 - 0.022);
-      const fee = Math.floor((total - amount) * 100) / 100;
+      const fee = Math.round((total - amount) * 100) / 100;
 
       return `$${fee.toFixed(2)}`;
     },


### PR DESCRIPTION
#### What's this PR do?
Frontend JS now calls `round()` on fees instead of `floor()`.

#### Why are we doing this? How does it help us?
The backend was rounding up/down, but the frontend was only rounding down. This caused the frontend to display some fees off by 1 cent.

#### How should this be manually tested?
- Enter $20 on production, and you will see a fee of $0.75 on the frontend.
- Enter $20 locally, and you will see a fee of $0.76 on the frontend.
  - If you perform the donation (with fee), you can confirm Salesforce shows $20.76 as the total.
- You can compare frontend and backend calculation:
  https://github.com/texastribune/donations/blob/f5fcc5b8f9c27845d1d5ac353de476d821291c75/static/js/src/connected-elements/PayFees.vue#L53-L54
  https://github.com/texastribune/donations/blob/f5fcc5b8f9c27845d1d5ac353de476d821291c75/charges.py#L44-L52

#### How should this change be communicated to end users?
- Inform membership team.

#### Are there any smells or added technical debt to note?
- There is still some question about what the actual fee is that Stripe is taking, but this codebase would not be affected by a fee change on their end. We are hard coded to a particular rate.

#### What are the relevant tickets?
- https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwvu5Kdv9ASOAfh2/recX7kzowQu3TYdWj?blocks=hide
