### PR TITLE
update amount on blast-promo page

### DIFF
--- a/app.py
+++ b/app.py
@@ -574,6 +574,7 @@ def the_blast_promo_form():
         form=form,
         campaign_id=campaign_id,
         referral_id=referral_id,
+        amount="250",
         installment_period="yearly",
         key=app.config["STRIPE_KEYS"]["publishable_key"],
         bundles=bundles,

--- a/templates/blast-promo.html
+++ b/templates/blast-promo.html
@@ -10,7 +10,7 @@ The Blast | The Texas Tribune
 }
 
 .subscription li label[for='amount-0']:after {
-    content: '$200'
+    content: '$250'
 }
 </style>
 {% endblock %}
@@ -83,7 +83,7 @@ The Blast | The Texas Tribune
                 <div class="col col_5--xl form__box grid_separator">
                     <ul class="subscription grid_row">
                         <li class="col grid_separator">
-                            <input checked id="amount-0" name="amount" type="radio" value="200">
+                            <input checked id="amount-0" name="amount" type="radio" value="250">
                             <label for="amount-0">Annual</label>
                         </li>
                     </ul>

--- a/templates/blast-promo.html
+++ b/templates/blast-promo.html
@@ -6,22 +6,22 @@ The Blast | The Texas Tribune
 <script src="{{ url_for('static', filename='js/blast.js') }}"></script>
 <style>
     .subscription li label[for='amount-0']:before {
-    content: 'Discounted rate';
-}
+        content: 'Discounted rate';
+    }
 
-.subscription li label[for='amount-0']:after {
-    content: '$250'
-}
+    .subscription li label[for='amount-0']:after {
+        content: '${{ amount }}'
+    }
 </style>
 {% endblock %}
 
 {% block og_meta %}
-  <meta property="og:url" content="https://support.texastribune.org/blast-promo">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-blast.png') }}">
-  <meta property="og:title" content="The Blast | The Texas Tribune">
-  <meta property="og:type" content="website">
-  <meta property="og:description" content="The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on happenings in the Capitol three times a week for insiders. Don’t get left behind. Subscribe today.">
-  <meta name="twitter:card" content="summary_large_image">
+    <meta property="og:url" content="https://support.texastribune.org/blast-promo">
+    <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-blast.png') }}">
+    <meta property="og:title" content="The Blast | The Texas Tribune">
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on happenings in the Capitol three times a week for insiders. Don’t get left behind. Subscribe today.">
+    <meta name="twitter:card" content="summary_large_image">
 {% endblock %}
 
 {% block content %}
@@ -83,7 +83,7 @@ The Blast | The Texas Tribune
                 <div class="col col_5--xl form__box grid_separator">
                     <ul class="subscription grid_row">
                         <li class="col grid_separator">
-                            <input checked id="amount-0" name="amount" type="radio" value="250">
+                            <input checked id="amount-0" name="amount" type="radio" value="{{ amount }}">
                             <label for="amount-0">Annual</label>
                         </li>
                     </ul>


### PR DESCRIPTION
#### What's this PR do?
Updates blast promo amount to $250

#### Why are we doing this? How does it help us?
Request from membership

#### How should this be manually tested?
Spin up donations
visit /blast-promo and ensure the cost is $250 instead of $200

#### How should this change be communicated to end users?
I'll let Reese know.

#### Are there any smells or added technical debt to note?
We will need to turn this page off after the promo is done running. We'll also need to have Anna manually bump up any promo'd accounts to the regular cost after a year (though we'll likely be able to handle this after the stripe conversion project on our side).

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recTYdpmPLrXgeu6T?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
