### PR TITLE
adding docker-compose for running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY config /app/config
 COPY package.json /app/
 COPY package-lock.json /app/
 COPY babel.config.js /app/
+COPY tests.py /app/
 RUN npm install
 
 RUN pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ COPY config /app/config
 COPY package.json /app/
 COPY package-lock.json /app/
 COPY babel.config.js /app/
-COPY tests.py /app/
 RUN npm install
 
 RUN pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: build
 
 test-new:
 	docker-compose up -d --build
-	docker-compose run --entrypoint=python test -m pytest "tests.py" --cov=.
+	docker-compose run test
 
 reconcile-email:
 	docker build --tag=sf-py2 -f Dockerfile.py2 .

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ test: build
 		--entrypoint=python \
 		texastribune/checkout:dev /usr/local/bin/py.test /app/tests.py --cov=/app
 
+test-new:
+	docker-compose up -d --build
+	docker-compose run --entrypoint=python test -m pytest "tests.py" --cov=.
+
 reconcile-email:
 	docker build --tag=sf-py2 -f Dockerfile.py2 .
 	docker run --env-file=${DOCKER_ENV_FILE} --rm --interactive --tty --name=py2 sf-py2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    ports:
+      - 80:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
       - .:/app
     ports:
       - 80:5000
+    entrypoint: python -m pytest "tests.py" --cov=.


### PR DESCRIPTION
#### What's this PR do?
Adds a docker-compose file and a make command to use that file for testing purposes.

#### Why are we doing this? How does it help us?
The overall goal here is to make this app more readable and to make the developer experience more frictionless. I'm hoping that moving more of the pieces that are handled in the Makefile (redis, rabbitmq, shell) to docker-compose. Also, this allows us to actually utilize the pytest library we're already installing instead of pulling down a version each time we run make test.

#### How should this be manually tested?
Run make test and make test-new and ensure you see similar results.

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
This will eventually replace the current 'test' make command, but for now, I wanted this pr to be simply additive.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recm2EZHmnXTRlB2b?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
