### PR TITLE
Remove remaining SMD promos

### DIFF
--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-smd23.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
@@ -41,10 +41,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s">
-              <!-- <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p> -->
-              <p>It’s not too late to give! Help us unlock a $17,000 match from the Tribune’s board of directors today.</p>
-            </div>
+            <!--<div class="c-message grid_separator has-text-gray-dark t-size-s">
+               <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div>-->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
#### What's this PR do?

Drops the special SMD social image and promotional text above the form

#### Why are we doing this? How does it help us?

The campaign has ended

#### How should this be manually tested?

Just confirm the page looked like it did pre SMD

#### How should this change be communicated to end users?

I'll let Kassie know

#### Are there any smells or added technical debt to note?

nope

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwgojVPEBjVPvt59/recR3gpOJFABxg54K?blocks=hide


