### PR TITLE
🦶 Remove revlab from site footer

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -173,17 +173,6 @@
               >Privacy Policy</a
             >
           </li>
-
-          <li>
-            <a
-              href="https://revlab.org"
-              title="RevLab"
-              ga-event-category="navigation"
-              ga-event-action="footer link click"
-              ga-event-label="revlab"
-              >RevLab</a
-            >
-          </li>
           <li>
             <a
               href="https://www.texastribune.org/corrections/"


### PR DESCRIPTION
#### What's this PR do?

Removes the revlab link in the footer. Similar to https://github.com/texastribune/texastribune/pull/5028.

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
