### PR TITLE
Add canceled subscription functionality

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1475,7 +1475,7 @@ def log_rdo(contact, subscription):
     return rdo
 
 
-def update_next_opportunity(opps=[], subscription_id=None, transaction_id=None, amount=0):
+def update_next_opportunity(opps=[], subscription_id=None, transaction_id=None, amount=None):
 
     if not opps:
         opps = Opportunity.list(
@@ -1493,8 +1493,10 @@ def update_next_opportunity(opps=[], subscription_id=None, transaction_id=None, 
     charge_details = {
         "StageName": "Closed Won",
         "Stripe_Transaction_ID__c": transaction_id,
-        "Amount": amount
     }
+    if amount:
+        charge_details["Amount"] = amount
+
     response = Opportunity.update_stage([opp], charge_details)
 
 

--- a/server/charges.py
+++ b/server/charges.py
@@ -58,6 +58,7 @@ def amount_to_charge_stripe(form=None):
     https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
     """
     amount = float(form["amount"])
+    logging.info(f"pay_fees_value: {form['pay_fees_value']}")
     if form["pay_fees_value"]:
         if form["installment_period"] == None:
             total = (amount + 0.30) / (1 - 0.022)

--- a/tests/cassettes/test_webhooks/test_log_rdo.yaml
+++ b/tests/cassettes/test_webhooks/test_log_rdo.yaml
@@ -65,7 +65,7 @@ interactions:
         \ \"latest_invoice\": \"in_1N6yrwCUjA8cLeTjjVP1TslF\",\n  \"livemode\": false,\n
         \ \"metadata\": {\n    \"campaign_id\": \"limeinthecoconut123456789\",\n    \"pay_fees\":
         \"x\",\n    \"reason\": \"Let the good times roll\",\n    \"referral_id\":
-        \"puppysong123456789\"\n  },\n  \"next_pending_invoice_item_invoice\": null,\n
+        \"puppysong123456789\"\n    \"donor_selected_amount\": \"15\",\n  },\n  \"next_pending_invoice_item_invoice\": null,\n
         \ \"on_behalf_of\": null,\n  \"pause_collection\": null,\n  \"payment_settings\":
         {\n    \"payment_method_options\": null,\n    \"payment_method_types\": null,\n
         \   \"save_default_payment_method\": \"off\"\n  },\n  \"pending_invoice_item_interval\":

--- a/tests/cassettes/test_webhooks/test_log_rdo.yaml
+++ b/tests/cassettes/test_webhooks/test_log_rdo.yaml
@@ -65,7 +65,7 @@ interactions:
         \ \"latest_invoice\": \"in_1N6yrwCUjA8cLeTjjVP1TslF\",\n  \"livemode\": false,\n
         \ \"metadata\": {\n    \"campaign_id\": \"limeinthecoconut123456789\",\n    \"pay_fees\":
         \"x\",\n    \"reason\": \"Let the good times roll\",\n    \"referral_id\":
-        \"puppysong123456789\"\n    \"donor_selected_amount\": \"15\",\n  },\n  \"next_pending_invoice_item_invoice\": null,\n
+        \"puppysong123456789\"\n  },\n  \"next_pending_invoice_item_invoice\": null,\n
         \ \"on_behalf_of\": null,\n  \"pause_collection\": null,\n  \"payment_settings\":
         {\n    \"payment_method_options\": null,\n    \"payment_method_types\": null,\n
         \   \"save_default_payment_method\": \"off\"\n  },\n  \"pending_invoice_item_interval\":

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -156,3 +156,6 @@ def test_name_splitter():
     first_name, last_name = name_splitter('Harry Nilsson')
     assert first_name=='Harry'
     assert last_name=='Nilsson'
+
+def test_close_rdo():
+    pass

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -156,6 +156,3 @@ def test_name_splitter():
     first_name, last_name = name_splitter('Harry Nilsson')
     assert first_name=='Harry'
     assert last_name=='Nilsson'
-
-def test_close_rdo():
-    pass

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -123,7 +123,7 @@ def test_log_rdo(mocker):
     assert resp.referral_id=="puppysong123456789"
     assert resp.agreed_to_pay_fees==True
     assert resp.encouraged_by=="Let the good times roll"
-    assert resp.amount=="15.00"
+    assert resp.amount=="0.00"
     assert resp.installment_period=="monthly"
     assert resp.quarantined==False
     assert resp.stripe_card_expiration=="2024-02-29"


### PR DESCRIPTION
#### What's this PR do?
* adds webhook pieces that listen for a subscription cancelled event and react accordingly
* cleans up the new stripe subscription pieces
* restructures quarantined records to use the legacy donation flow for now

#### Why are we doing this? How does it help us?
* we need to account for cancelled subscriptions
* quarantined records are too much of a bear to lump in with non-quarantined records on /donate
    * we'll have to have further discussions on how we want to handle these going forward, but this works in the meantime

#### How should this be manually tested?
Running through the same steps as seen in [this pr](https://github.com/texastribune/donations/pull/1073) but in staging and sans the set up steps should suffice. Should also test giving a donation that would naturally be quarantined.

#### How should this change be communicated to end users?
We'll let membership know when the new updates are launched

#### Are there any smells or added technical debt to note?
As mentioned above, this solution for quarantined records is only temporary until we can get a better handle on what needs the membership team has for quarantined records

#### What are the relevant tickets?


#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
