### PR TITLE
Update business form to create subscriptions

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -425,7 +425,7 @@ def add_stripe_donation(form=None, customer=None, donation_type=None, bad_actor_
         if donation_type == "membership":
             subscription = create_custom_subscription(customer=customer, form=form, quarantine=quarantine)
         else:
-            subscription = create_subscription(donation_type=donation_type, level="big_tex", customer=customer, form=form, quarantine=quarantine)
+            subscription = create_subscription(donation_type=donation_type, customer=customer, form=form, quarantine=quarantine)
         return True
 
 
@@ -1416,10 +1416,10 @@ def create_custom_subscription(customer=None, form=None, quarantine=None):
 
 
 # TODO can these funcs be moved somewhere else? (maybe util.py?)
-def create_subscription(donation_type=None, level=None, customer=None, form=None, quarantine=None):
+def create_subscription(donation_type=None, customer=None, form=None, quarantine=None):
     app.logger.info(f"business form: {form}")
     logging.info(f"business form: {form}")
-    product = STRIPE_PRODUCTS[level]
+    product = STRIPE_PRODUCTS[form["level"]]
     prices_list = stripe.Price.list(product=product)
     price = find_price(
         prices=prices_list,

--- a/server/config.py
+++ b/server/config.py
@@ -66,9 +66,12 @@ STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 STRIPE_PRODUCTS = {
     "sustaining": os.getenv("STRIPE_PRODUCT_SUSTAINING", ""),
     "circle": os.getenv("STRIPE_PRODUCT_CIRCLE", ""),
-    "big_tex": os.getenv("STRIPE_PRODUCT_BIG_TEX", ""),
-    "lone_star": os.getenv("STRIPE_PRODUCT_LONE_STAR", ""),
-    "hats_off": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
+    "bigTexMonthly": os.getenv("STRIPE_PRODUCT_BIG_TEX", ""),
+    "bigTexYearly": os.getenv("STRIPE_PRODUCT_BIG_TEX", ""),
+    "loneStarMonthly": os.getenv("STRIPE_PRODUCT_LONE_STAR", ""),
+    "loneStarYearly": os.getenv("STRIPE_PRODUCT_LONE_STAR", ""),
+    "hatsOffMonthly": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
+    "hatsOffYearly": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
     "blast": os.getenv("STRIPE_PRODUCT_BLAST", "")
 }
 

--- a/server/config.py
+++ b/server/config.py
@@ -66,7 +66,9 @@ STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 STRIPE_PRODUCTS = {
     "sustaining": os.getenv("STRIPE_PRODUCT_SUSTAINING", ""),
     "circle": os.getenv("STRIPE_PRODUCT_CIRCLE", ""),
-    "business": os.getenv("STRIPE_PRODUCT_BUSINESS", ""),
+    "big_tex": os.getenv("STRIPE_PRODUCT_BIG_TEX", ""),
+    "lone_star": os.getenv("STRIPE_PRODUCT_LONE_STAR", ""),
+    "hats_off": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
     "blast": os.getenv("STRIPE_PRODUCT_BLAST", "")
 }
 

--- a/server/forms.py
+++ b/server/forms.py
@@ -95,6 +95,7 @@ class BusinessMembershipForm(BaseForm):
     shipping_street = StringField("Shipping Street", [validators.Length(max=255)])
     shipping_postalcode = StringField(u"ZIP Code", [validators.Length(max=20)])
     installment_period = StringField([validators.AnyOf(["yearly", "monthly"])])
+    level = HiddenField(u"Level", [validators.InputRequired()])
 
 
 class BlastForm(FlaskForm):

--- a/server/static/js/src/entry/business/TopForm.vue
+++ b/server/static/js/src/entry/business/TopForm.vue
@@ -228,6 +228,7 @@
       <hidden name="pay_fees_value" :store-module="storeModule" />
       <hidden name="installment_period" :store-module="storeModule" />
       <hidden name="amount" :store-module="storeModule" />
+      <hidden name="level" :store-module="storeModule" />
     </div>
   </form>
 </template>

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -117,7 +117,7 @@ def test_log_rdo(mocker):
     contact.first_name = "Harry"
     contact.last_name = "Nilsson"
 
-    resp = log_rdo(contact, subscription)
+    resp = log_rdo(contact=contact, subscription=subscription)
     assert resp.stripe_customer=="cus_NskMDwAXZUuQFZ"
     assert resp.campaign_id=="limeinthecoconut123456789"
     assert resp.referral_id=="puppysong123456789"


### PR DESCRIPTION
#### What's this PR do? 
Adds stripe subscription creation to our /business membership form. Also uses our new stripe webhooks functionality to listen for subscription creation success events from business membership submission and logs recurring donations and opportunities in Salesforce respectively.

#### Why are we doing this? How does it help us?
This is the next step in a larger modernization project for the donations app that will give us a more reliable and less brittle system for handling recurring donations. This update modernizes the /business donation form in particular.

#### How should this be manually tested?

* Add new business form env vars
     * Add `STRIPE_PRODUCT_BIG_TEX` `STRIPE_PRODUCT_LONE_STAR` and `STRIPE_PRODUCT_HATS_OFF` to your env-docker file. [Internal note: See wiki **Keys** for details](https://texastribune.atlassian.net/wiki/spaces/TECH/pages/2273837059/Navigating+Salesforce#Keys)
* Visit the [business form](https://donations-testing.herokuapp.com/business) on staging
* Try giving donations for different tiers (i.e. "Big Tex", "Lone Star", etc.), at different intervals, with or without agreeing to cover fees using a [test card](https://stripe.com/docs/testing#cards)
* For each of these donations...
    * In our stripe dashboard, make sure you are in "Test Mode" (upper corner)
    * Choose the "Customers" tab and you should see the gift you made
        * Note that it will show the First Name/Last Name combo you provided, not the company name 
        * <img width="1085" alt="Screen Shot 2023-07-07 at 7 21 30 AM" src="https://github.com/texastribune/donations/assets/88053677/fcecb1e9-c7df-46fa-a450-6f5d5e6d3424">
    * Clicking through to the customer you added should show a screen listing a Business subscription
    * <img width="1290" alt="Screen Shot 2023-07-07 at 7 22 22 AM" src="https://github.com/texastribune/donations/assets/88053677/90f56573-07db-4b08-a2e1-751b4f967080">
    * Login to our salesforce sandbox (deets listed under "Salesforce Test (2023 refactor)")
    * Follow the instructions [here](https://texastribune.atlassian.net/wiki/spaces/TECH/pages/2273837059/Navigating+Salesforce) to ensure that the donation came through on the salesforce end as expected

#### How should this change be communicated to end users?
We'll let membership team know when this is deployed.

#### Are there any smells or added technical debt to note?
The handling of stripe products is admittedly messy. The hope is that when we refactor the frontend, we can incorporate some more stripe pieces and have the products/prices loaded with the rest of the page instead of being referenced/grabbed here in the midst of the post request.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rec4vLTin8wF7HlrP?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
