### PR TITLE
Move blast to subscriptions

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1370,7 +1370,8 @@ def create_payment_intent(customer=None, form=None, quarantine=None):
 def get_contact(customer):
     app.logger.info(f"Incoming customer in get_contact: {customer}")
     first_name, last_name = name_splitter(customer.get("name", ""))
-    zipcode = customer.get("address", {}).get("postal_code", None)
+    address = customer.get("address", None)
+    zipcode = address.get("postal_code", None) if address else None
     app.logger.info("----Getting contact....")
     contact = Contact.get_or_create(
         email=customer.get("email", None),

--- a/server/app.py
+++ b/server/app.py
@@ -859,7 +859,7 @@ def payout_paid(event):
         # get the Opportunity Ids that go with those charges
         sfc = SalesforceConnection()
         opps_to_update = sfc.query(query)
-        opps_to_updkate = [o["Id"] for o in opps_to_update]
+        opps_to_update = [o["Id"] for o in opps_to_update]
 
         # set the payout date on those opportunities
         response = sfc.update_payout_dates(opps_to_update, payout_date)

--- a/server/app.py
+++ b/server/app.py
@@ -65,12 +65,10 @@ DONATION_TYPE_INFO = {
     "membership": {
         "type": "Recurring Donation",
         "description": "Texas Tribune Sustaining Membership",
-        "installments": None,
     },
     "business_membership": {
         "type": "Business Membership",
         "description": "Texas Tribune Business Membership",
-        "installments": None,
     },
     "circle": {
         "description": "Texas Tribune Circle Membership",
@@ -78,7 +76,6 @@ DONATION_TYPE_INFO = {
     "blast": {
         "type": "The Blast",
         "description": "Blast Subscription",
-        "installments": 0,
     },
 }
 
@@ -1452,7 +1449,7 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
     rdo.encouraged_by = sub_meta.get("encouraged_by", None)
     rdo.lead_source = "Stripe"
     rdo.amount = sub_meta.get("donor_selected_amount", 0)
-    rdo.installments = donation_type_info.get("installments", None)
+    rdo.installments = None
     rdo.installment_period = installment_period
     rdo.open_ended_status = "Open"
     rdo.quarantined = True if sub_meta.get("quarantine", None) else False

--- a/server/config.py
+++ b/server/config.py
@@ -72,7 +72,8 @@ STRIPE_PRODUCTS = {
     "loneStarYearly": os.getenv("STRIPE_PRODUCT_LONE_STAR", ""),
     "hatsOffMonthly": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
     "hatsOffYearly": os.getenv("STRIPE_PRODUCT_HATS_OFF", ""),
-    "blast": os.getenv("STRIPE_PRODUCT_BLAST", "")
+    "blast": os.getenv("STRIPE_PRODUCT_BLAST", ""),
+    "blastTaxExempt": os.getenv("STRIPE_PRODUCT_BLAST_TAX_EXEMPT", ""),
 }
 
 #######

--- a/server/forms.py
+++ b/server/forms.py
@@ -120,6 +120,7 @@ class BlastForm(FlaskForm):
     description = HiddenField(u"Description")
     pay_fees = BooleanField(u"Agree to pay fees")
     pay_fees_value = HiddenField(u"Pay Fees Value")
+    level = HiddenField(u"Subscription level")
 
 
 class BlastPromoForm(FlaskForm):

--- a/server/static/js/blast.js
+++ b/server/static/js/blast.js
@@ -34,7 +34,8 @@ var listen_for_installments = function() {
 var payFeeAmount = function() {
   var goalAmount = parseFloat($('input[name="amount"]:checked').val()),
       // https://support.stripe.com/questions/passing-the-stripe-fee-on-to-customers
-      totalAmount = (goalAmount + .30) / (1 - 0.022);
+      // updating to include subscription costs as of 7/23
+      totalAmount = (goalAmount + .30) / (1 - 0.027);
       // Fee rounded to two decimal places.
       feeAmount = Math.round((totalAmount - goalAmount) * 100) / 100,
       payFeeElement = $('#pay-fee-amount span');

--- a/server/templates/blast-form.html
+++ b/server/templates/blast-form.html
@@ -32,6 +32,7 @@
     <form action="/submit-blast" method="post" class="blastform grid_separator--l">
       <input name="campaign_id" id="campaign_id" value="{{ campaign_id }}" type="hidden">
       <input name="referral_id" id="referral_id" value="{{ referral_id }}" type="hidden">
+      <input name="level" id="level" type="hidden">
       <div class="form-outer-section outer-section narrow">
 
         <header class="grid_separator--l">

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -117,7 +117,7 @@ def test_log_rdo(mocker):
     contact.first_name = "Harry"
     contact.last_name = "Nilsson"
 
-    resp = log_rdo(contact=contact, subscription=subscription)
+    resp = log_rdo(type="membership", contact=contact, subscription=subscription)
     assert resp.stripe_customer=="cus_NskMDwAXZUuQFZ"
     assert resp.campaign_id=="limeinthecoconut123456789"
     assert resp.referral_id=="puppysong123456789"


### PR DESCRIPTION
#### What's this PR do?
Adds stripe subscription creation to our /blast subscription form. Also uses our new stripe webhooks functionality to listen for subscription creation success events from blast subscription form submission and logs recurring donations and opportunities in Salesforce respectively.

#### Why are we doing this? How does it help us?
This is the next step in a larger modernization project for the donations app that will give us a more reliable and less brittle system for handling recurring donations. This update modernizes the /blast subscription form in particular.

#### How should this be manually tested?
**Use staging for testing - the way stripe sends events to any and all webhook listeners can cause duplicates to occur on the salesforce side if we're all testing locally at the same time or while the testing endpoint is turned on**

* Visit the [blast form](https://donations-testing.herokuapp.com/blastform) on staging
* Give donations for each of the three buttons, with or without agreeing to cover fees using a [test card](https://stripe.com/docs/testing#cards)
* For each of these donations...
    * In our stripe dashboard, make sure you are in "Test Mode" (upper corner)
    * Choose the "Customers" tab and you should see the gift you made
    * Clicking through to the customer you added should show a screen listing a Blast subscription
        * <img width="1273" alt="Screen Shot 2023-07-11 at 3 13 31 PM" src="https://github.com/texastribune/donations/assets/88053677/6ede2e62-76e3-4045-ad79-ba3a3d16db89">
    * Login to our salesforce sandbox (deets listed under "Salesforce Test (2023 refactor)")
    * Follow the instructions [here](https://texastribune.atlassian.net/wiki/spaces/TECH/pages/2273837059/Navigating+Salesforce) to ensure that the donation came through on the salesforce end as expected

#### How should this change be communicated to end users?
We'll let membership team know when this is deployed.

#### Are there any smells or added technical debt to note?
Only that the blast form functionality is handled a bit differently than the other three for whatever reason. It would be worth it to bring it into the fold, so to say, but that seems outside of the scope of this project, so a few things may look a little hacky here and there, but they are in the interest of adhering to the current structure as closely as possible.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rec0QDNNIGRzWIMYJ?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
