### PR TITLE
Post business subs updates

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,6 +45,9 @@
     "DEFAULT_MAIL_SENDER": {
       "required": true
     },
+    "ENABLE_BAD_ACTOR_API": {
+      "required": true
+    },
     "ENABLE_PORTAL": {
       "required": true
     },

--- a/server/app.py
+++ b/server/app.py
@@ -877,6 +877,10 @@ def customer_subscription_created(event):
     # link the Contact with the Account. Lastly, send a notification to Slack (if configured)
     # and send an email notification about the new membership.
     if donation_type == "business_membership":
+        if contact.work_email is None:
+            contact.work_email = contact.email
+            contact.save()
+
         account = get_account(customer)
         rdo = log_rdo(type=donation_type, account=account, subscription=subscription)
         affiliation = Affiliation.get_or_create(
@@ -891,7 +895,8 @@ def customer_subscription_created(event):
         transaction_id=invoice["charge"],
         amount=invoice.get("amount_paid", 0) / 100
     )
-    notify_slack(contact=contact, rdo=rdo)
+    if donation_type != "blast":
+        notify_slack(contact=contact, rdo=rdo)
 
 
 @celery.task(name="app.payment_intent_succeeded")

--- a/server/app.py
+++ b/server/app.py
@@ -29,6 +29,7 @@ from .config import (
     AMAZON_MERCHANT_ID,
     AMAZON_SANDBOX,
     BLOCK_LIST,
+    ENABLE_BAD_ACTOR_API,
     ENABLE_PORTAL,
     ENABLE_SENTRY,
     FLASK_SECRET_KEY,
@@ -396,7 +397,7 @@ def add_stripe_donation(form=None, customer=None, donation_type=None, bad_actor_
     payer wait for them. It sends a notification about the donation to Slack (if configured).
     """
     quarantine = False
-    if donation_type == "membership":
+    if donation_type == "membership" and ENABLE_BAD_ACTOR_API:
         bad_actor_response = BadActor(bad_actor_request=bad_actor_request)
         quarantine = bad_actor_response.quarantine
 

--- a/server/config.py
+++ b/server/config.py
@@ -133,6 +133,7 @@ AUTH0_PORTAL_AUDIENCE = os.getenv(
 ########
 # Bad Actor
 #
+ENABLE_BAD_ACTOR_API = bool_env("ENABLE_BAD_ACTOR_API")
 BAD_ACTOR_API_URL = os.getenv("BAD_ACTOR_API_URL", None)
 BAD_ACTOR_NOTIFICATION_URL = os.getenv("BAD_ACTOR_NOTIFICATION_URL", None)
 BLOCK_LIST = os.getenv("BLOCK_LIST", None)

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -508,7 +508,6 @@ class Opportunity(SalesforceObject, CampaignMixin):
             "StageName": self.stage_name,
             "Type": self.type,
             "Stripe_Customer_ID__c": self.stripe_customer,
-            "Stripe_Subscription_Id__c": self.stripe_subscription,
             "Referral_ID__c": self.referral_id,
             "LeadSource": self.lead_source,
             "Description": self.description,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -402,7 +402,6 @@ def test__format_opportunity():
         "RecordType": {"Name": "Membership"},
         "StageName": "Pledged",
         "Stripe_Customer_ID__c": "cus_78MqJSBejMN9gn",
-        "Stripe_Subscription_Id__c": None,
         "Referral_ID__c": "1234",
         "Description": "The Texas Tribune Membership",
         "Stripe_Agreed_to_pay_fees__c": True,


### PR DESCRIPTION
#### What's this PR do?
Fixes a few issues around stripe subscription updates. Namely...
    * removes "Stripe_Subscription_Id__c" field from Opportunity's __init__ so that we can leave the handling of this field to Salesforce
    * adds the saving of a work_email in salesforce for business memberships
    * updates the slack notification process to ignore blast subscriptions so that we don't see those in #donate

#### Why are we doing this? How does it help us?
Most importantly, we can now let salesforce update an RDO's child opportunities based off of the subscription id tied to said RDO. The other two are minor bugs that have come up.

#### How should this be manually tested?
* the blast in #donate bug - really the only actionable one here... on staging add a blast subscription and check that it didn't show up in #tech-testing
* need to circle back with Anna about updating our salesforce sandbox so we can test this properly
* we can't really test the email bug in staging... will just need to make another business donation when up in prod to check that a follow-up email is sent from the trip

#### How should this change be communicated to end users?
Shouldn't need to be.

#### Are there any smells or added technical debt to note?
Not really.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rec2HxpgD0fzs1weP?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
