### PR TITLE
Opp description fix

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -911,7 +911,6 @@ def customer_subscription_created(event):
     update_next_opportunity(
         opps=rdo.opportunities(),
         invoice=invoice if invoice else stripe.Invoice.retrieve(latest_invoice),
-        subscription=subscription
     )
 
     if donation_type != "blast":
@@ -924,7 +923,7 @@ def payment_intent_succeeded(event):
     payment_intent = event['data']['object']
     invoice_id = payment_intent['invoice']
     if invoice_id:
-        invoice = stripe.Invoice.retrieve(invoice_id, expand=['subscription'])
+        invoice = stripe.Invoice.retrieve(invoice_id)
         app.logger.info(f"Payment intent invoice: {invoice}")
 
         # the initial invoice tied to a subscription is handled in the
@@ -932,7 +931,6 @@ def payment_intent_succeeded(event):
         if invoice['billing_reason'] != "subscription_create":
             update_next_opportunity(
                 invoice=invoice,
-                subscription=invoice["subscription"]
             )
     else:
         customer = stripe.Customer.retrieve(payment_intent['customer'])
@@ -1515,7 +1513,7 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
     return rdo
 
 
-def update_next_opportunity(opps=[], invoice=None, subscription=None):
+def update_next_opportunity(opps=[], invoice=None):
     if not opps:
         opps = Opportunity.list(
             stage_name="Pledged", stripe_subscription_id=invoice["subscription"]
@@ -1528,11 +1526,11 @@ def update_next_opportunity(opps=[], invoice=None, subscription=None):
         if opportunity.expected_giving_date == today
     ][0]
     app.logger.info(f'opps with giving_date today on subscription_id: {opp}')
+    transaction_id = invoice["charge"]
     amount = invoice.get("amount_paid", 0) / 100
     charge_details = {
         "StageName": "Closed Won",
-        "Stripe_Transaction_ID__c": invoice.get("charge"),
-        "Description": subscription.get("description", "Texas Tribune Membership"),
+        "Stripe_Transaction_ID__c": transaction_id,
     }
     if amount:
         charge_details["Amount"] = amount

--- a/server/app.py
+++ b/server/app.py
@@ -923,8 +923,10 @@ def payment_intent_succeeded(event):
     payment_intent = event['data']['object']
     invoice_id = payment_intent['invoice']
     if invoice_id:
-        invoice = stripe.Invoice.retrieve(invoice_id)
+        invoice = stripe.Invoice.retrieve(invoice_id, expand=['subscription'])
         app.logger.info(f"Payment intent invoice: {invoice}")
+        description = invoice.get("subscription", {}).get("description", "Texas Tribune Membership")
+        stripe.PaymentIntent.modify(payment_intent["id"], description=description)
 
         # the initial invoice tied to a subscription is handled in the
         # customer_subscription_created func, so we ignore it here

--- a/server/app.py
+++ b/server/app.py
@@ -923,10 +923,17 @@ def payment_intent_succeeded(event):
     payment_intent = event['data']['object']
     invoice_id = payment_intent['invoice']
     if invoice_id:
-        invoice = stripe.Invoice.retrieve(invoice_id, expand=['subscription'])
+        try:
+            invoice = stripe.Invoice.retrieve(invoice_id, expand=['subscription'])
+        except stripe.error.StripeError as e:
+            app.logger.error(f"Issue finding invoice for {payment_intent['id']} with message: {e}")
+            return # process can not continue without invoice and will need to be retriggered from stripe
         app.logger.info(f"Payment intent invoice: {invoice}")
         description = invoice.get("subscription", {}).get("description", "Texas Tribune Membership")
-        stripe.PaymentIntent.modify(payment_intent["id"], description=description)
+        try:
+            stripe.PaymentIntent.modify(payment_intent["id"], description=description)
+        except stripe.error.StripeError as e:
+            app.logger.error(f"Issue modifying {payment_intent['id']} with message: {e}")
 
         # the initial invoice tied to a subscription is handled in the
         # customer_subscription_created func, so we ignore it here

--- a/server/app.py
+++ b/server/app.py
@@ -911,6 +911,7 @@ def customer_subscription_created(event):
     update_next_opportunity(
         opps=rdo.opportunities(),
         invoice=invoice if invoice else stripe.Invoice.retrieve(latest_invoice),
+        subscription=subscription
     )
 
     if donation_type != "blast":
@@ -923,7 +924,7 @@ def payment_intent_succeeded(event):
     payment_intent = event['data']['object']
     invoice_id = payment_intent['invoice']
     if invoice_id:
-        invoice = stripe.Invoice.retrieve(invoice_id)
+        invoice = stripe.Invoice.retrieve(invoice_id, expand=['subscription'])
         app.logger.info(f"Payment intent invoice: {invoice}")
 
         # the initial invoice tied to a subscription is handled in the
@@ -931,6 +932,7 @@ def payment_intent_succeeded(event):
         if invoice['billing_reason'] != "subscription_create":
             update_next_opportunity(
                 invoice=invoice,
+                subscription=invoice["subscription"]
             )
     else:
         customer = stripe.Customer.retrieve(payment_intent['customer'])
@@ -1513,7 +1515,7 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
     return rdo
 
 
-def update_next_opportunity(opps=[], invoice=None):
+def update_next_opportunity(opps=[], invoice=None, subscription=None):
     if not opps:
         opps = Opportunity.list(
             stage_name="Pledged", stripe_subscription_id=invoice["subscription"]
@@ -1526,11 +1528,11 @@ def update_next_opportunity(opps=[], invoice=None):
         if opportunity.expected_giving_date == today
     ][0]
     app.logger.info(f'opps with giving_date today on subscription_id: {opp}')
-    transaction_id = invoice["charge"]
     amount = invoice.get("amount_paid", 0) / 100
     charge_details = {
         "StageName": "Closed Won",
-        "Stripe_Transaction_ID__c": transaction_id,
+        "Stripe_Transaction_ID__c": invoice.get("charge"),
+        "Description": subscription.get("description", "Texas Tribune Membership"),
     }
     if amount:
         charge_details["Amount"] = amount


### PR DESCRIPTION
#### What's this PR do?
Fixes the descriptions on payment intents so that they reflect the description from the subscription they're tied to.

#### Why are we doing this? How does it help us?
This was a request from Morgan. They look frequently at payout info which displays the payment intent description, initially not helpful at seeing at a glance which subscription the payment is for.

#### How should this be manually tested?
* make sure ENABLE_BAD_ACTOR_API is set to False locally
* spin up the app locally
* visit /donate and give a recurring gift (monthly or yearly is fine) using a [test card](https://stripe.com/docs/testing#cards)
* visit our stripe dashboard and make sure you're in test mode (upper right corner)
* in the left nav, choose Payments
* you should see your payment towards the top with 'Texas Tribune Sustaining Membership' listed in the 'Description' column.
    * you'll see older donations with either "Subscription creation" or "INVOICE ##########"... these are an example of the old and wrong way of capturing descriptions
    * <img width="776" alt="Screen Shot 2023-08-03 at 12 11 51 PM" src="https://github.com/texastribune/donations/assets/88053677/b1c16466-9d45-412f-8d82-0cb3a7de34d8">

#### How should this change be communicated to end users?
I'll update Morgan when it's deployed.

#### Are there any smells or added technical debt to note?
N/A

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recdHh8boUvade3ci?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
