### PR TITLE
added about us

### DIFF
--- a/server/templates/includes/navbar.html
+++ b/server/templates/includes/navbar.html
@@ -13,6 +13,11 @@
           </a>
         </li>
         <li class="c-navbar__item is-hidden-until-bp-l">
+          <a href="https://www.texastribune.org/about/" class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated" ga-on="click" ga-event-category="navigation" ga-event-action="top nav click" ga-event-label="about us">
+            <strong>About us</strong>
+          </a>
+        </li>
+        <li class="c-navbar__item is-hidden-until-bp-l">
           <a href="https://www.texastribune.org/topics/texas-tribune-investigations/" class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated" ga-on="click" ga-event-category="navigation" ga-event-action="top nav click" ga-event-label="investigations">
             <strong>Investigations</strong>
           </a>


### PR DESCRIPTION
#### What's this PR do?
Added an 'About Us' button in the nav bar next to the Donate button that redirects the user to
https://www.texastribune.org/about/?_ga=2.256202507.1294043355.1691688168-63906706.1690382665


| Before | After |
| ----- | ----- |
| ![image](https://github.com/texastribune/donations/assets/89395611/04b48a69-0f18-4ba7-bc92-a940532343ec) | ![image](https://github.com/texastribune/donations/assets/89395611/42dc3421-71d7-42be-b7cc-eb0278c5ad4a) |

#### Why are we doing this? How does it help us?
- We want to make it easier for users to learn about the Tribune. Usually the About Us page is in the footer so we want to make it more accessible. 

#### How should this be manually tested?
- Since this involves changes to the mobile site as well, both the front-end of the desktop and mobile needs to be tested
- Desktop and mobile can follow the following format to test it. Clicking on the About Us button should be redirected to https://www.texastribune.org/about/?_ga=2.155054136.1294043355.1691688168-63906706.1690382665

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viw2hmgtJLOzaXcaO/recKniw38gfY0Yln8?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
