### PR TITLE
Stopping Blast Promo Redirect

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -232,7 +232,7 @@ support.texastribune.org.
 
 
 @app.route("/blast-vip")
-@app.route("/blast-promo")
+# @app.route("/blast-promo")
 def the_blastvip_form():
     return redirect("/blastform", code=302)
 
@@ -642,7 +642,7 @@ def business_form():
     )
 
 
-# @app.route("/blast-promo")
+@app.route("/blast-promo")
 def the_blast_promo_form():
     bundles = get_bundles("old")
     form = BlastPromoForm()


### PR DESCRIPTION
#### What's this PR do?
- /blast-promo no longer redirect to /blastform

#### Why are we doing this? How does it help us?
- running a promotion

#### How should this be manually tested?
- /blast-promo should render the blast promo page

#### How should this change be communicated to end users?
- Reese O.

#### Are there any smells or added technical debt to note?
- Kinda wish we had a dynamic way to toggle this.

#### What are the relevant tickets?
- https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwULM503frwBhAOe/recsvdqqAIxtlKNni?blocks=hide