### PR TITLE
UMP UI updates for FMD23

### DIFF
--- a/server/static/js/src/entry/account/components/BaseButton.vue
+++ b/server/static/js/src/entry/account/components/BaseButton.vue
@@ -6,12 +6,7 @@
     :disabled="disabled"
     @click="onClick"
   >
-    <span v-if="link">
-      <a href="https://airtable.com/appyo1zuQd8f4hBVx/shr6ZCx0OAnhrm1BJ">{{ text }}</a>
-    </span>
-    <span v-else>
-      {{ text }}
-    </span>
+    {{ text }}
   </button>
 </template>
 
@@ -38,11 +33,6 @@ export default {
     extraClasses: {
       type: Array,
       default: () => [],
-    },
-
-    link: {
-      type: String,
-      required: false,
     },
   },
 

--- a/server/static/js/src/entry/account/components/BaseButton.vue
+++ b/server/static/js/src/entry/account/components/BaseButton.vue
@@ -6,7 +6,12 @@
     :disabled="disabled"
     @click="onClick"
   >
-    {{ text }}
+    <span v-if="link">
+      <a href="https://airtable.com/appyo1zuQd8f4hBVx/shr6ZCx0OAnhrm1BJ">{{ text }}</a>
+    </span>
+    <span v-else>
+      {{ text }}
+    </span>
   </button>
 </template>
 
@@ -33,6 +38,11 @@ export default {
     extraClasses: {
       type: Array,
       default: () => [],
+    },
+
+    link: {
+      type: String,
+      required: false,
     },
   },
 

--- a/server/static/js/src/entry/account/components/ConfirmModal.vue
+++ b/server/static/js/src/entry/account/components/ConfirmModal.vue
@@ -9,10 +9,10 @@
   >
     <div class="c-modal">
       <div class="c-modal__heading l-align-center-children has-padding">
-        <h2 class="t-size-b t-align-center t-lh-b">{{ heading }}</h2>
+        <h2 class="t-size-b t-align-center t-lh-b has-text-gray-dark">{{ heading }}</h2>
       </div>
       <div class="c-modal__body" v-if="message">
-        {{ message }}
+        <div class="t-align-center" v-html="message"></div>
       </div>
       <ul class="c-modal__buttons l-width-full">
         <li>

--- a/server/static/js/src/entry/account/components/ConfirmModal.vue
+++ b/server/static/js/src/entry/account/components/ConfirmModal.vue
@@ -8,8 +8,11 @@
     adaptive
   >
     <div class="c-modal">
-      <div class="c-modal__top l-align-center-children has-padding">
-        <h2 class="t-size-b t-align-center t-lh-b">{{ message }}</h2>
+      <div class="c-modal__heading l-align-center-children has-padding">
+        <h2 class="t-size-b t-align-center t-lh-b">{{ heading }}</h2>
+      </div>
+      <div class="c-modal__body" v-if="message">
+        {{ message }}
       </div>
       <ul class="c-modal__buttons l-width-full">
         <li>
@@ -47,9 +50,13 @@ export default {
       type: Function,
       required: true,
     },
-    message: {
+    heading: {
       type: String,
       required: true,
+    },
+    message: {
+      type: String,
+      required: false,
     },
     acceptText: {
       type: String,

--- a/server/static/js/src/entry/account/components/MessageModal.vue
+++ b/server/static/js/src/entry/account/components/MessageModal.vue
@@ -8,15 +8,17 @@
   >
     <div class="c-modal">
       <div class="c-modal__heading l-align-center-children has-padding">
-        <h2 class="t-size-b t-align-center t-lh-b">{{ heading }}</h2>
+        <h2 class="t-size-b t-align-center t-lh-b has-text-gray-dark">
+          <span class="c-icon c-icon--baseline t-size-b">
+            <svg aria-hidden="true">
+              <use class="has-text-success" v-if="messageType == 'success'" href="#check"></use>
+              <use v-if="messageType == 'failure'" href="#close"></use>
+            </svg>
+          </span>
+          {{ heading }}
+        </h2>
       </div>
       <div class="t-align-center">
-        <span class="c-icon c-icon--teal c-icon--baseline t-size-xl">
-          <svg aria-hidden="true">
-            <use v-if="messageType == 'success'" href="#check"></use>
-            <use v-if="messageType == 'failure'" href="#close"></use>
-          </svg>
-        </span>
         <div class="c-modal__body" v-if="messageBody">
           <div v-html="messageBody"></div>
         </div>

--- a/server/static/js/src/entry/account/components/MessageModal.vue
+++ b/server/static/js/src/entry/account/components/MessageModal.vue
@@ -41,9 +41,7 @@
 </template>
 
 <script>
-import BaseButton from './BaseButton.vue';
 export default {
-  components: { BaseButton },
   name: 'MessageModal',
 
   props: {

--- a/server/static/js/src/entry/account/components/MessageModal.vue
+++ b/server/static/js/src/entry/account/components/MessageModal.vue
@@ -1,0 +1,54 @@
+<template>
+  <modal
+    :max-width="450"
+    name="messageModal"
+    width="80%"
+    height="auto"
+    adaptive
+  >
+    <div class="c-modal">
+      <div class="c-modal__heading l-align-center-children has-padding">
+        <h2 class="t-size-b t-align-center t-lh-b">{{ heading }}</h2>
+      </div>
+      <div class="t-align-center">
+        <span class="c-icon c-icon--teal c-icon--baseline t-size-xl">
+          <svg aria-hidden="true">
+            <use v-if="messageType == 'success'" href="#check"></use>
+            <use v-if="messageType == 'failure'" href="#close"></use>
+          </svg>
+        </span>
+        <div class="c-modal__body" v-if="messageBody">
+          <div v-html="messageBody"></div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="c-modal__close has-bg-white has-text-gray"
+      aria-label="close modal"
+      @click="$emit('onClose')"
+    >
+      <icon name="close" :display="{ size: 'xxs', color: 'gray' }" />
+    </button>
+  </modal>
+</template>
+
+<script>
+export default {
+  name: 'MessageModal',
+
+  props: {
+    heading: {
+      type: String,
+      required: true,
+    },
+    messageType: {
+      type: String,
+      required: true,
+    },
+    messageBody: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>

--- a/server/static/js/src/entry/account/components/MessageModal.vue
+++ b/server/static/js/src/entry/account/components/MessageModal.vue
@@ -21,6 +21,12 @@
       <div class="t-align-center">
         <div class="c-modal__body" v-if="messageBody">
           <div v-html="messageBody"></div>
+          <base-button
+            v-if="link"
+            :text="linkText"
+            :display="{ isFullWidth: false, size: 's' }"
+            @onClick="onClick(link)"
+          />
         </div>
       </div>
     </div>
@@ -35,7 +41,9 @@
 </template>
 
 <script>
+import BaseButton from './BaseButton.vue';
 export default {
+  components: { BaseButton },
   name: 'MessageModal',
 
   props: {
@@ -43,14 +51,32 @@ export default {
       type: String,
       required: true,
     },
+
     messageType: {
       type: String,
       required: true,
     },
+
     messageBody: {
       type: String,
       required: true,
     },
+
+    link: {
+      type: String,
+      required: false,
+    },
+
+    linkText: {
+      type: String,
+      required: false,
+    },
   },
+
+  methods: {
+    onClick(link) {
+      window.open(link);
+    }
+  }
 };
 </script>

--- a/server/static/js/src/entry/account/routes/edit-contact-info/Index.vue
+++ b/server/static/js/src/entry/account/routes/edit-contact-info/Index.vue
@@ -24,7 +24,7 @@
 
     <confirm-modal
       :resolve="checkModalResolve"
-      :message="'You have unsaved changes'"
+      :heading="'You have unsaved changes'"
       :reject-text="'Keep editing'" 
       :accept-text="'Do not save'" />
   </div>

--- a/server/static/js/src/entry/account/routes/membership/components/CardUpdateNew.vue
+++ b/server/static/js/src/entry/account/routes/membership/components/CardUpdateNew.vue
@@ -9,7 +9,7 @@
   >
     <div class="c-modal">
       <div class="c-modal__heading l-align-center-children">
-        <h3 class="t-size-b t-align-center t-lh-b">Update Card</h3>
+        <h3 class="t-size-b t-align-center t-lh-b has-text-gray-dark">Update Card</h3>
       </div>
       <validation-observer v-slot="{ handleSubmit }">
         <form @submit.prevent="handleSubmit(patchCard)">

--- a/server/static/js/src/entry/account/routes/membership/components/CardUpdateNew.vue
+++ b/server/static/js/src/entry/account/routes/membership/components/CardUpdateNew.vue
@@ -8,12 +8,13 @@
     adaptive
   >
     <div class="c-modal">
-      <div class="c-modal__top l-align-center-children">
+      <div class="c-modal__heading l-align-center-children">
         <h3 class="t-size-b t-align-center t-lh-b">Update Card</h3>
       </div>
       <validation-observer v-slot="{ handleSubmit }">
         <form @submit.prevent="handleSubmit(patchCard)">
           <manual-pay
+            class="c-modal__body"
             :card="card"
             base-classes="form__manual"
             @setCardValue="setCardValue"
@@ -30,7 +31,7 @@
     <button
       class="c-modal__close has-bg-white has-text-gray"
       aria-label="close modal"
-      @click="$emit('onClose', true)"
+      @click="$emit('onClose')"
     >
       <icon name="close" :display="{ size: 'xxs', color: 'gray' }" />
     </button>
@@ -93,7 +94,7 @@ export default {
       await this.updateStripe();
       if (!this.updateFailure) {
         // opportunities in salesforce can update in the background and log any errors
-        this.updateSalesforce();
+        await this.updateSalesforce();
         const successMessage = `Card ending in ${this.stripeCard.last4}, expiring ${this.stripeCard.exp_month}/${this.stripeCard.exp_year} has been saved \
           for donation of $${this.rdo.amount} (${this.rdo.period})`;
         this.$emit(
@@ -148,8 +149,8 @@ export default {
       }
     },
 
-    updateSalesforce() {
-      this[USER_TYPES.updateRdoCard]({
+    async updateSalesforce() {
+      await this[USER_TYPES.updateRdoCard]({
         rdoId: this.rdo.id,
         card: {
           last4: this.stripeCard.last4,

--- a/server/static/js/src/entry/account/routes/membership/components/RecurringOrCircle.vue
+++ b/server/static/js/src/entry/account/routes/membership/components/RecurringOrCircle.vue
@@ -113,11 +113,13 @@
       @onClose="onClose('cardModal')" />
     <confirm-modal
       :resolve="checkModalResolve"
-      :heading="'Cancel Recurring Donation?'"
+      :heading="confirmHeading"
+      :message="confirmBody"
       :reject-text="'No'"
-      :accept-text="'Yes'" />
+      :accept-text="'Yes'" 
+      @onClose="onClose('confirmModal')" />
     <message-modal
-      :heading="heading"
+      :heading="messageHeading"
       :messageType="messageType"
       :messageBody="messageBody" 
       @onClose="onClose('messageModal')" />
@@ -173,7 +175,9 @@ export default {
       openConfirmModal: false,
       successMessage: '',
       failureMessage: '',
-      heading: '',
+      confirmHeading: '',
+      confirmBody: '',
+      messageHeading: '',
       messageBody: '',
       messageType: '',
       declinedCard: false,
@@ -278,7 +282,7 @@ export default {
     },
   
     onSuccess(message) {
-      this.heading = "Credit Card Update Succeeded"
+      this.messageHeading = "We've updated your payment info"
       this.messageBody = message;
       this.messageType = 'success';
       this.$modal.hide('cardModal');
@@ -286,7 +290,7 @@ export default {
     },
   
     onFailure(message) {
-      this.heading = "Credit Card Update Failed";
+      this.messageHeading = "Credit Card Update Failed";
       this.messageBody = message;
       this.messageType = 'failure';
       this.$modal.hide('cardModal');
@@ -299,6 +303,10 @@ export default {
 
     async cancelDonation(rdo) {
       this.updateFailure = false;
+      this.confirmHeading = 'Cancel Recurring Donation?';
+      this.confirmBody = `<p>By selecting <b>yes</b>, you are canceling your recurring donation
+                            and will not be charged at your next scheduled renewal date.
+                          </p>`;
 
       this.$modal.show('confirmModal');
 
@@ -313,11 +321,15 @@ export default {
             rdoId: rdo.id,
             stripeSubscriptionId: rdo.stripe_subscription_id,
           });
-          this.heading='Donation Cancelled Successfully';
-          this.messageBody = `<p>Recurring donation of $${rdo.amount} (${rdo.period}) has been cancelled.</p>
-                              <p>We're sorry to see you go. If possible, could you let us know why 
-                                <a href="https://airtable.com/appyo1zuQd8f4hBVx/shr6ZCx0OAnhrm1BJ">here</a>?
-                              </p>`;
+          this.messageHeading='Donation Cancelled Successfully';
+          this.messageBody = `<div class="t-size-s">Recurring donation of $${rdo.amount} (${rdo.period}) has been cancelled.</div>
+                              <hr/>
+                              <div>We're sorry to see you go! Can you let us know why?</div>
+                              <base-button
+                                :text="'Share your feedback'"
+                                :link="'https://airtable.com/appyo1zuQd8f4hBVx/shr6ZCx0OAnhrm1BJ'"
+                                :display="{ size: 's' }"
+                              />`;
           this.messageType = 'success';
         } catch (err) {
           this.updateFailure = true;
@@ -337,7 +349,7 @@ export default {
             ) {
               this.failureMessage = 'The submitted card was declined or invalid. Please check your information and resubmit'
             }
-            this.heading = "Donation Cancelation Failed";
+            this.messageHeading = "Donation Cancelation Failed";
             this.messageBody = this.failureMessage;
             this.messageType = 'failure';
           }

--- a/server/static/js/src/entry/account/routes/membership/components/RecurringOrCircle.vue
+++ b/server/static/js/src/entry/account/routes/membership/components/RecurringOrCircle.vue
@@ -121,7 +121,9 @@
     <message-modal
       :heading="messageHeading"
       :messageType="messageType"
-      :messageBody="messageBody" 
+      :messageBody="messageBody"
+      :link="messageLink"
+      :linkText="messageLinkText"
       @onClose="onClose('messageModal')" />
   </section>
 </template>
@@ -159,6 +161,18 @@ export default {
       type: Object,
       required: true,
     },
+    firstName: {
+      type: String,
+      required: true,
+    },
+    lastName: {
+      type: String,
+      required: true,
+    },
+    email: {
+      type: String,
+      required: true,
+    },
     recurringTransactions: {
       type: Array,
       required: true,
@@ -180,6 +194,8 @@ export default {
       messageHeading: '',
       messageBody: '',
       messageType: '',
+      messageLink: '',
+      messageLinkText: '',
       declinedCard: false,
       checkModalResolve: () => {},
       stagedRdo: {},
@@ -290,7 +306,7 @@ export default {
     },
   
     onFailure(message) {
-      this.messageHeading = "Credit Card Update Failed";
+      this.messageHeading = "We weren't able to update your payment info";
       this.messageBody = message;
       this.messageType = 'failure';
       this.$modal.hide('cardModal');
@@ -321,16 +337,13 @@ export default {
             rdoId: rdo.id,
             stripeSubscriptionId: rdo.stripe_subscription_id,
           });
-          this.messageHeading='Donation Cancelled Successfully';
+          this.messageHeading="We've cancelled your recurring donation";
           this.messageBody = `<div class="t-size-s">Recurring donation of $${rdo.amount} (${rdo.period}) has been cancelled.</div>
-                              <hr/>
-                              <div>We're sorry to see you go! Can you let us know why?</div>
-                              <base-button
-                                :text="'Share your feedback'"
-                                :link="'https://airtable.com/appyo1zuQd8f4hBVx/shr6ZCx0OAnhrm1BJ'"
-                                :display="{ size: 's' }"
-                              />`;
+                              <hr class="has-b-btm-marg"/>
+                              <div class="has-b-btm-marg">We're sorry to see you go! Can you let us know why?</div>`;
           this.messageType = 'success';
+          this.messageLink = `https://airtable.com/appmeSLgv6yUW4HcC/shraO409FOodYJs68?prefill_First+name=${this.firstName}&prefill_Last+name=${this.lastName}&prefill_Email=${this.email}`;
+          this.messageLinkText = "Share your feedback";
         } catch (err) {
           this.updateFailure = true;
           logError({err, level: 'warning'})
@@ -349,7 +362,7 @@ export default {
             ) {
               this.failureMessage = 'The submitted card was declined or invalid. Please check your information and resubmit'
             }
-            this.messageHeading = "Donation Cancelation Failed";
+            this.messageHeading = "We weren't able to cancel your donation";
             this.messageBody = this.failureMessage;
             this.messageType = 'failure';
           }

--- a/server/static/js/src/entry/account/routes/membership/containers/RecurringOrCircleContainer.vue
+++ b/server/static/js/src/entry/account/routes/membership/containers/RecurringOrCircleContainer.vue
@@ -3,6 +3,9 @@
     <recurring-or-circle
       v-if="shouldShow"
       :next-transaction="user.nextTransaction"
+      :first-name="user.firstName"
+      :last-name="user.lastName"
+      :email="user.email"
       :recurring-transactions="user.recurringTransactions"
       :can-view-as="tokenUser.canViewAs"
     />

--- a/server/static/sass/ds/6-components/_modal.scss
+++ b/server/static/sass/ds/6-components/_modal.scss
@@ -8,7 +8,7 @@
 
   &__heading {
     display: flex;
-    height: 2.75rem;
+    height: 3.75rem;
   }
 
   &__body {

--- a/server/static/sass/ds/6-components/_modal.scss
+++ b/server/static/sass/ds/6-components/_modal.scss
@@ -6,6 +6,17 @@
     height: 6.25rem;
   }
 
+  &__heading {
+    display: flex;
+    height: 2.75rem;
+  }
+
+  &__body {
+    padding-left: $size-b;
+    padding-right: $size-b;
+    padding-bottom: $size-b;
+  }
+
   &__buttons {
     display: grid;
     gap: .1rem;


### PR DESCRIPTION
#### What's this PR do?
Mostly focused on getting the new cancel feature and the updated cc update feature cleaned up for public consumption.

#### Why are we doing this? How does it help us?
The above mentioned features were rolled out a few weeks ago for use by the membership team, but some ui elements needed cleaning up before rolling out to membership at large. We've also added a message pop-up after an attempted update or cancellation that provides more context.

#### How should this be manually tested?
* Visit the UMP on the [staging site](https://donations-testing.herokuapp.com/account) (best to do this in Chrome)
* Click on membership in the left nav
    * <img width="484" alt="Screen Shot 2023-09-12 at 9 15 55 AM" src="https://github.com/texastribune/donations/assets/88053677/a943aa44-64b4-412d-a88d-c7b4a6c73b63">
* Choose a recurring donation to edit and fill out the form in the pop-up with a [Stripe test card](https://stripe.com/docs/testing#cards)
    * <img width="809" alt="Screen Shot 2023-09-12 at 9 19 01 AM" src="https://github.com/texastribune/donations/assets/88053677/7d7ebc8d-b68f-472f-9493-6341dbadefa1">
* After the update goes through, you should see a success message with helpful information
    * <img width="521" alt="Screen Shot 2023-09-12 at 9 20 16 AM" src="https://github.com/texastribune/donations/assets/88053677/9e9f2199-5dae-4347-8f3b-9e8a06a14a08">
* Attempt deleting the same recurring donation by clicking the delete button and confirming in the pop-up
    * <img width="598" alt="Screen Shot 2023-09-12 at 9 21 32 AM" src="https://github.com/texastribune/donations/assets/88053677/14deb510-5c16-41c8-a95e-91789aba76f8">
* After the cancellation goes through, you should see a success message with helpful information and a link out to a form
    * <img width="610" alt="Screen Shot 2023-09-12 at 9 22 50 AM" src="https://github.com/texastribune/donations/assets/88053677/b5de9273-91b8-43d2-8658-d4d5f060fbfc">
* Follow the link and make sure it takes you to an airtable form
    * <img width="1080" alt="Screen Shot 2023-09-12 at 9 23 36 AM" src="https://github.com/texastribune/donations/assets/88053677/938b1e55-e8ee-4b8b-9eeb-e01ce57d8e46">

#### How should this change be communicated to end users?
We'll let membership team know so they can take a look at the updates.

#### Are there any smells or added technical debt to note?
The main thing I need a second look at right now, is some of the classes in the MessageModal (c-icon, c-icon__teal, etc.) For some reason, these aren't coming through. The link also just looks like regular text instead of having any highlighting.

Besides that, I'm curious if it makes sense to have this separate MessageModal component or if it makes more sense to lump the MessageModal and the ConfirmModal into one component and just have it handle various kinds of input. The main reason why I separated these two out is just to keep the code cleaner, but there's definitely some overlap between the two components, html-wise.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rec2k4dWU9hqZXcAU?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
