### PR TITLE
Remove FMD promo message (deploy 9/25)

### DIFF
--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -41,11 +41,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s">
-               <p>
-                During our Fall Member Drive, <strong>donate $50 as a new or renewing member, or $15 as a current member</strong>, by 11:59 p.m. Central time on Sunday, Sept. 24, and you’ll be entered to win a hotel getaway in Austin. Full terms at <strong><a style="color:#323a44; text-decoration: underline;" href="https://trib.it/getaway2023">trib.it/getaway2023</a></strong>.
-               </p>
-            </div>
+            <!--<div class="c-message grid_separator has-text-gray-dark t-size-s">
+               <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div>-->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
**🗒️ To be deployed morning of 9/25**

#### What's this PR do?

Removes the yellow message box

#### Why are we doing this? How does it help us?

The contest ends on 9/24

#### How should this be manually tested?

Yellow box should no longer be there

#### How should this change be communicated to end users?

I'll let Kassie know

#### Are there any smells or added technical debt to note?
no

#### What are the relevant tickets?

part of FMD tasks

