### PR TITLE
Stop rdo creation for open invoices

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -871,7 +871,7 @@ def customer_subscription_created(event):
     invoice = stripe.Invoice.retrieve(subscription["latest_invoice"])
     if invoice["status"] == "open":
         raise Exception(f"Subscription {subscription['id']} was created but its first invoice is still open.\
-                           Please follow up with the subscription to proceed.")
+                        Please follow up with the subscription to proceed.")
     customer = stripe.Customer.retrieve(subscription["customer"])
     contact = get_contact(customer)
 

--- a/server/app.py
+++ b/server/app.py
@@ -1083,6 +1083,7 @@ def stripehook():
     if event.type == "payout.paid":
         payout_paid.delay(event)
     if event.type == "customer.subscription.created":
+        app.logger.info(f"subscription created event: {event}")
         customer_subscription_created.delay(event)
     if event.type == "payment_intent.succeeded":
         payment_intent_succeeded.delay(event)

--- a/server/app.py
+++ b/server/app.py
@@ -869,10 +869,10 @@ def customer_subscription_created(event):
     subscription = event["data"]["object"]
     donation_type = subscription["metadata"]["donation_type"]
     latest_invoice = subscription["latest_invoice"]
-    invoice = None
+    invoice = stripe.Invoice.retrieve(latest_invoice)
     customer = stripe.Customer.retrieve(subscription["customer"])
     contact = get_contact(customer)
-    app.logger.info(f'the invoice is here => {latest_invoice}')
+    app.logger.info(f'the invoice is here => {invoice}')
 
     # For a business membership, look for a matching Account (or create one).
     # Then add a recurring donation to the Account. Next, add an Affiliation to

--- a/server/app.py
+++ b/server/app.py
@@ -872,6 +872,7 @@ def customer_subscription_created(event):
     invoice = None
     customer = stripe.Customer.retrieve(subscription["customer"])
     contact = get_contact(customer)
+    app.logger.info(f'the invoice is here => {latest_invoice}')
 
     # For a business membership, look for a matching Account (or create one).
     # Then add a recurring donation to the Account. Next, add an Affiliation to
@@ -1407,7 +1408,7 @@ def create_payment_intent(customer=None, form=None, quarantine=None):
 
 
 def get_contact(customer):
-    app.logger.info(f"Incoming customer in get_contact: {customer}")
+    # app.logger.info(f"Incoming customer in get_contact: {customer}")
     first_name, last_name = name_splitter(customer.get("name"))
     address = customer.get("address", None)
     zipcode = address.get("postal_code", None) if address else None

--- a/server/app.py
+++ b/server/app.py
@@ -870,9 +870,8 @@ def customer_subscription_created(event):
     donation_type = subscription["metadata"]["donation_type"]
     invoice = stripe.Invoice.retrieve(subscription["latest_invoice"])
     if invoice["status"] == "open":
-        app.logger.warning(f"Subscription {subscription['id']} was created but its first invoice is still open.\
+        raise Exception(f"Subscription {subscription['id']} was created but its first invoice is still open.\
                            Please follow up with the subscription to proceed.")
-        return ''
     customer = stripe.Customer.retrieve(subscription["customer"])
     contact = get_contact(customer)
 


### PR DESCRIPTION
#### What's this PR do?
For newly created subscriptions, this adds a check that looks at the invoice tied to the subscription and makes sure it has been paid before building/saving an rdo in Salesforce.

#### Why are we doing this? How does it help us?
This is a catch-all for anytime a subscription (recurring donation) is created but its corresponding first invoice isn't paid (for whatever reason). This bug will keep us from inaccurately logging incomplete recurring donations in both Salesforce and slack.

#### How should this be manually tested?
* visit [our staging site](https://donations-testing.herokuapp.com/donate)
* give a gift using the "Always blocked" or "highest risk" cards mentioned [here](https://stripe.com/docs/testing#fraud-prevention)
* after a minute or so, you should see a warning pop up in #tech-warnings about the gift
    * notably, there will be no mention of the donation in #test-test
* go back to the staging donation page and donate using one of the [valid test cards](https://stripe.com/docs/testing#cards)
* you should see THIS donation end up in the #tech-test channel (and get no message in #tech-warnings)

#### How should this change be communicated to end users?
We'll let Morgan and the membership team know.

#### Are there any smells or added technical debt to note?
We'll want to revisit where the messages from this go to. Eventually we want a dedicated #donations-alert (or something similar) channel.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recsY37WFQGxu1oOT?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
