### PR TITLE
📧 Business Email Unicode Fix

### DIFF
--- a/server/util.py
+++ b/server/util.py
@@ -188,7 +188,7 @@ def send_email(recipient, subject, body, sender=None):
 
     TO = recipient if type(recipient) is list else [recipient]
     SUBJECT = subject
-    TEXT = body
+    TEXT = body.encode('ascii', errors='ignore').decode('ascii')
 
     # Prepare actual message
     message = """\From: %s\nTo: %s\nSubject: %s\n\n%s
@@ -206,6 +206,7 @@ def send_email(recipient, subject, body, sender=None):
         server.sendmail(FROM, TO, message)
         server.close()
         logging.debug("successfully sent the mail")
+        logging.debug(message)
     except Exception as e:
         logging.error(f"failed to send mail: {e}")
 


### PR DESCRIPTION
#### What's this PR do?
- Unicode characters are now stripped out of new business membership emails.

#### Why are we doing this? How does it help us?
- Some business input unicode characters (specifically in the "organization name" field), which causes the email to fail to send.

#### How should this be manually tested?
- Make a /business donation (on staging) with a unicode character in the "organization name". See example:
![Screenshot 2023-10-13 at 12 22 35 PM](https://github.com/texastribune/donations/assets/4173104/d4d747a2-6b78-48c2-ad31-d8f48bd66b76)
- View Mailtrap via heroku. You should see the email, and the unicode character should have been stripped out.

#### What are the relevant tickets?
- https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwULM503frwBhAOe/recIiPjXi5A3YNiWS?blocks=hide
