### PR TITLE
Require zip code in form

### DIFF
--- a/server/static/js/src/entry/donate/constants.js
+++ b/server/static/js/src/entry/donate/constants.js
@@ -35,7 +35,7 @@ export const BASE_FORM_STATE = {
   zipcode: {
     value: '',
     isValid: false,
-    validator: validators.isEmptyOrZip,
+    validator: validators.isZip,
     message: 'Enter a 5-digit zip code',
   },
   amount: {


### PR DESCRIPTION
#### What's this PR do?

Updates the front-end validation to be more strict about zip codes

#### Why are we doing this? How does it help us?

This is what bad actor bot says when missing zips are encountered:

```
Oct 15 15:00:41 donations-prod app/worker.1 INFO root/bad_actor:241 - {'detail': [{'loc': ['body', 'zipcode'], 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}]}
 Oct 15 15:00:41 donations-prod app/worker.1 WARNING root/bad_actor:61 - Unable to call bad actor API: 2 validation errors for BadActorResponse
 ```

#### How should this be manually tested?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

Not sure if this is the best approach for this issue. Will revisit during business hours

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
