### PR TITLE
update invoice ref on circle donations

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -899,7 +899,7 @@ def customer_subscription_created(event):
         # at subscription creation here.
         if donation_type == "circle" and invoice_status == "draft":
             stripe.Invoice.finalize_invoice(invoice["id"])
-            stripe.Invoice.pay(invoice["id"])
+            invoice = stripe.Invoice.pay(invoice["id"])
 
         rdo = log_rdo(type=donation_type, contact=contact, subscription=subscription)
 


### PR DESCRIPTION
#### What's this PR do?
This is an update that uses the final version of an invoice for circle memberships (instead of the initial version).

#### Why are we doing this? How does it help us?
Because circle memberships are scheduled subscriptions, an initial invoice comes to us in a draft mode and we have to manually finalize it and pay it (rather than have it be automatically finalized/paid by stripe after an hour, which is the default). The knock-on effect of that is that values we're used to reffing on an invoice are either missing or null on the initial invoice. Thus, we'll start reffing the invoice that is a result of running stripe.Invoice.pay() going forward. This only effects new circle memberships, fyi.

#### How should this change be communicated to end users?
I'll let Morgan know, as the old way we were handling this was causing some amounts to not get updated properly on the SF side (amount not including the added fees, etc.)

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recR31i2PAouAhP2E?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
