### PR TITLE
adding skip_sync logic

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -868,15 +868,15 @@ def customer_subscription_created(event):
     # It starts by looking for a matching Contact (or creating one).
     subscription_id = event["data"]["object"]["id"]
     subscription = stripe.Subscription.retrieve(subscription_id, expand=["latest_invoice"])
-    sub_meta = subscription["metadata"]
+    subscription_meta = subscription["metadata"]
 
     # When migrating existing recurring donations from salesforce to stripe subscriptions, we pass a field
     # called "skip_sync" to the subscription metadata to let us know that we don't need to push anything back
     # to salesforce. In that instance, we exit the function at this point.
-    if sub_meta.get("skip_sync", False):
+    if subscription_meta.get("skip_sync", False):
         return None
 
-    donation_type = sub_meta.get("donation_type", subscription["plan"]["metadata"].get("type", "membership"))
+    donation_type = subscription_meta.get("donation_type", subscription["plan"]["metadata"].get("type", "membership"))
 
     invoice = subscription["latest_invoice"]
     invoice_status = invoice["status"]

--- a/server/app.py
+++ b/server/app.py
@@ -868,7 +868,15 @@ def customer_subscription_created(event):
     # It starts by looking for a matching Contact (or creating one).
     subscription_id = event["data"]["object"]["id"]
     subscription = stripe.Subscription.retrieve(subscription_id, expand=["latest_invoice"])
-    donation_type = subscription["metadata"].get("donation_type", subscription["plan"]["metadata"].get("type", "membership"))
+    sub_meta = subscription["metadata"]
+
+    # When migrating existing recurring donations from salesforce to stripe subscriptions, we pass a field
+    # called "skip_sync" to the subscription metadata to let us know that we don't need to push anything back
+    # to salesforce. In that instance, we exit the function at this point.
+    if sub_meta.get("skip_sync", False):
+        return None
+
+    donation_type = sub_meta.get("donation_type", subscription["plan"]["metadata"].get("type", "membership"))
 
     invoice = subscription["latest_invoice"]
     invoice_status = invoice["status"]


### PR DESCRIPTION
#### What's this PR do?
This adds a small chunk of code that keeps us from syncing anything to salesforce from a stripe event (like customer_subscription_created) when the field "skip_sync" is found on the subscription metadata.

#### Why are we doing this? How does it help us?
We add the "skip_sync" field to the subscription metadata when converting salesforce recurring donations to stripe subscriptions since the info already exists in salesforce. We also update the recurring donation with the stripe subscription id (the only thing we need to update in salesforce) immediately after creating the subscription, so we don't need to worry about listening for the stripe event. Overall, this small bit of logic helps us to not duplicate recurring donations in salesforce.

#### Are there any smells or added technical debt to note?
Once the conversions from salesforce to stripe are done, we can probably remove this code. I can't think of a situation where a donation shouldn't be synced to salesforce except for this one

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recJsJbQNe6QFgNMw?blocks=hide
