### PR TITLE
add auto-rejected messaging in slack

### DIFF
--- a/server/bad_actor.py
+++ b/server/bad_actor.py
@@ -33,6 +33,7 @@ class BadActorResponseItem(BaseModel):
 
 class BadActorResponse(BaseModel):
     overall_judgment: BadActorJudgmentType
+    auto_rejected: bool
     items: List[BadActorResponseItem]
 
 

--- a/server/bad_actor.py
+++ b/server/bad_actor.py
@@ -117,7 +117,15 @@ class BadActor:
             },
         ]
 
-        if not self.bad_actor_api_response.auto_rejected:
+        if self.bad_actor_api_response.auto_rejected:
+            slack_block.append({
+                "type": "section",
+                "fields": [{
+                    "type": "mrkdwn",
+                    "text": "Donation auto-rejected"
+                }]
+            })
+        else:
             slack_block.append({
                 "type": "actions",
                 "block_id": "choices",
@@ -141,14 +149,6 @@ class BadActor:
                         "value": json.dumps(self.transaction_data),
                     },
                 ],
-            })
-        else:
-            slack_block.append({
-                "type": "section",
-                "fields": [{
-                    "type": "mrkdwn",
-                    "text": "Donation auto-rejected by CageAI"
-                }]
             })
 
         return slack_block

--- a/server/bad_actor.py
+++ b/server/bad_actor.py
@@ -106,7 +106,7 @@ class BadActor:
         info_items = self._slackify_items(info_items)
         judgment_items = self._slackify_items(judgment_items)
 
-        return [
+        slack_block = [
             {
                 "type": "section",
                 "fields": info_items,
@@ -115,7 +115,10 @@ class BadActor:
                 "type": "section",
                 "fields": judgment_items,
             },
-            {
+        ]
+
+        if not self.bad_actor_api_response.auto_rejected:
+            slack_block.append({
                 "type": "actions",
                 "block_id": "choices",
                 "elements": [
@@ -138,8 +141,17 @@ class BadActor:
                         "value": json.dumps(self.transaction_data),
                     },
                 ],
-            },
-        ]
+            })
+        else:
+            slack_block.append({
+                "type": "section",
+                "fields": [{
+                    "type": "mrkdwn",
+                    "text": "Donation auto-rejected by CageAI"
+                }]
+            })
+
+        return slack_block
 
     def _send_to_slack(self):
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,10 +47,10 @@ bad_actor_request = {
 
 def test_bad_actor_init():
     bad_actor_response_suspect = BadActorResponse(
-        overall_judgment=BadActorJudgmentType.suspect, items=[]
+        overall_judgment=BadActorJudgmentType.suspect, auto_rejected=False, items=[]
     )
     bad_actor_response_good = BadActorResponse(
-        overall_judgment=BadActorJudgmentType.good, items=[]
+        overall_judgment=BadActorJudgmentType.good, auto_rejected=False, items=[]
     )
     bad_actor = BadActor(bad_actor_request=bad_actor_request)
 
@@ -85,6 +85,7 @@ def test_slackify_all():
     )
     bad_actor_response = BadActorResponse(
         overall_judgment=BadActorJudgmentType.suspect,
+        auto_rejected=False,
         items=[bad_actor_item1, bad_actor_item2],
     )
     contact = Contact(sf_connection=sf)


### PR DESCRIPTION
#### What's this PR do?
If a donation that needs to be quarantined is auto-rejected, we show a message mentioning the auto-rejection. The usual info around the donation is included, but no further action will be needed.

#### Why are we doing this? How does it help us?
Adding auto-reject logic has the ultimate goal of making life easier for the membership team by cutting down on the amount of quarantined donations.

#### How should this be manually tested?
Since there isn't a great way of mocking a bad recaptcha score, we'll just test that it doesn't block things it shouldn't be for now. To do that...

* visit the main donation page
* attempt giving a donation
* the donation should show as expected in #tech-test

#### How should this change be communicated to end users?
We'll let membership know about the new feature.

#### Are there any smells or added technical debt to note?
Not here. I do wonder if we need a more informative message about the auto-rejection. It could be good to include more info as to why the rejection happened, but maybe that's unnecessary.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recelzGtohXuop8EK?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] deploy portal pr
* [ ] deploy this pr
