### PR TITLE
Revert "EOY 2023" (🚀 Deploy 1/1/2024)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -61,7 +61,7 @@ from .util import (
 )
 
 ZONE = timezone(TIMEZONE)
-USE_THERMOMETER = True
+USE_THERMOMETER = False
 
 DONATION_TYPE_INFO = {
     "membership": {

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-eoy23.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
@@ -41,9 +41,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s">
-               <p><strong>Happening now: All new yearly and monthly donations to The Texas Tribune are matched!</strong> Yearly gifts are doubled, and monthly gifts are matched 12x. Help us unlock an extra $5,000 from NewsMatch to fund our journalism in 2024.</p>
-            </div>
+            <!--<div class="c-message grid_separator has-text-gray-dark t-size-s">
+               <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div>-->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
#### What's this PR do?
- hides the thermometer again
- removes the message box
- brings back the default share graphic

#### Why are we doing this? How does it help us?

The end of year giving campaign has ended

#### How should this be manually tested?

Not much to do here. Confirm the message bullets above are true

#### How should this change be communicated to end users?
I'll let Emily and Kassie know

#### Are there any smells or added technical debt to note?

Nope

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwb2L2CHc4ZWqkC5/recdEQ704aGcE1yhq?blocks=hide

