### PR TITLE
Subscription schedule updates

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -915,7 +915,7 @@ def customer_subscription_created(event):
 
     # if we already received an invoice object, as in the case of a circle membership,
     # use that, otherwise retrieve the latest invoice from stripe
-    if not subscription["trial_end"]:
+    if not subscription["trial_end"] and invoice_status != "draft":
         update_next_opportunity(
             opps=rdo.opportunities(),
             invoice=invoice,
@@ -972,7 +972,11 @@ def subscription_schedule_updated(event):
     app.logger.info(f"subscription schedule updated event: {event}")
 
     sub_schedule = event["data"]["object"]
-    rdo = RDO.get(subscription_id=sub_schedule["id"])
+    try:
+        rdo = RDO.get(subscription_id=sub_schedule["id"])
+    except Exception:
+        return # if no RDO is found with the given subscription schedule id, then there is nothing to update
+    
     subscription_id = sub_schedule["subscription"]
 
     if subscription_id:

--- a/server/app.py
+++ b/server/app.py
@@ -881,6 +881,9 @@ def customer_subscription_created(event):
     skip_notification = subscription_meta.get("skip_notification", False)
 
     invoice = subscription["latest_invoice"]
+    if type(invoice) is str:
+        invoice = stripe.Invoice.retrieve(invoice)
+
     invoice_status = invoice["status"]
     if invoice_status == "open":
         raise Exception(f"Subscription {subscription['id']} was created but its first invoice is still open.\


### PR DESCRIPTION
#### What's this PR do?
* adds a func for handling how to update an rdo's subscription_id when the sub id is finally created at time of invoicing
* updates the payment intent successful func to push an opp sync for pre-existing rdos that have a newly created subscription

#### Why are we doing this? How does it help us?
Now that we're using stripe's subscription scheduler to set subscriptions to start in the future (for legacy recurring donations that we want to first charge at some point in the future) we need to handle updating the subscription id on the rdo in salesforce when stripe finally creates that id (this doesn't happen until the first invoice is created on the day of the first charge). 

MORE CONTEXT: When the subscription schedule is created, a placeholder id (in the form of "sub_sched_xxxxxx") is set on the rdo so that we can still track the connection between salesforce and stripe and also so that we know stripe controls the rdo from this point forward. When the day comes for the schedule to create the first invoice (first for the subscription, but obviously not for the recurring donation as a whole, since we're talking about legacy donations), the subscription id is finally created, and this new fun switches out the new id (with form "sub_xxxxxx" with the sub_schedule id mentioned earlier).

#### How should this be manually tested?
Not a perfect solution because we have to get a lil' hacky with it, but let's go with [stripe clocks](https://dashboard.stripe.com/test/billing/subscriptions/test-clocks)!

* Start a new simulation (call it whatever you like and go with the current time for the start clock time)
* Once you're looking at your simulation, add a new user (add dropdown menu halfway down the page)
    * include name, email and currency (USD)
* Click the new customer and, when on the customer page, add a new payment method (card) using any of the [stripe test cards](https://stripe.com/docs/testing#cards)
* Now add a new subscription (while still on the customer page)
    * For "Duration", make sure the start date is the following day (for instance I set the start date to the 8th of Feb. since my clock was set to the 7th)
    * For "Pricing", search for "blast" and pick one of the products listed
    * Choose "Schedule subscription" at bottom of the form
* You should see the new scheduled subscription listed under "Subscriptions" and it should mention that it will start on whatever date you set
* Click on "Advance time" in the simulation toolbar at the top of the page
* Advance to the next day (your subscription start day) and set the clock to be between Midnight and 1 AM, then click "Advance"
![Screen Shot 2024-02-07 at 9 43 27 AM](https://github.com/texastribune/donations/assets/88053677/e0389eeb-604c-458f-bacd-39fdcc296f18)
    * Advancing to this time will cause the subscription creation and subscription schedule updated events to send to our web hook
    * Importantly, the payment intent succeeded event won't send until after 1 AM
    * The page will refresh and you should now see a draft invoice under "Invoices"
* Now visit the [webhooks event listing](https://dashboard.stripe.com/test/webhooks/we_1NJhEdG8bHZDNB6TiXvm6JrV) where you'll see the "customer.subscription.created" and the "subscription_schedule.updated" events you just triggered.
* Click on the "subscription_schedule.updated" event and copy the customer id in the "Request" response dict you see on the right side of the page
![Screen Shot 2024-02-07 at 9 57 35 AM](https://github.com/texastribune/donations/assets/88053677/ce3b0310-d3a0-47b3-abdb-7df86314b49b)
* In our salesforce sandbox, search for the recurring donation using this customer id (it should be the first result you get)
    * If you don't see a recurring donation after you search for the customer id, jump back to the web hook events listing and resend the "customer.subscritpion.created" event. Some quirk of the clock system sometimes makes it so the invoice is referenced in our code before it's actually created by the system and this means the record isn't created.
* Back on the stripe side, copy the sub_schedule id (format is "sub_sched_xxxxxxxxx")
![Screen Shot 2024-02-07 at 9 57 59 AM](https://github.com/texastribune/donations/assets/88053677/8fd1d2f6-ee3a-4851-80f0-576925b67ee3)
* Back in salesforce, update the "Stripe Subscription id" field to use the sub_schedule id you copied
    * Wait, why the hell are we doing this?
    * Okay, so we're trying to replicate the instance of a pre-existing salesforce RDO record that was given a temporary sub_sched id when I ran the conversion sweep
    * What we ran so far at least got an RDO record into salesforce for us, but now we have to force the scenario where it has a sub_sched id
* Okay, now we're cooking with gas (last few steps!)
* Choose the "subscription_schedule.updated" event and click the "Resend" button at the top of the Response listing
* Jump back to salesforce, refresh the page and you should see the "Stripe Subscription id" now lists an id with the format "sub_xxxxxxxxxxx"

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
There is some odd juggling we're having to do here between some of these events (subscription_schedule_updated, customer_subscription_created, payment_intent_success). I THINK all of the juggling is warranted, but I'd like to take some time on a Friday in the future to recheck the workflow of these to ascertain that there isn't a way to move around the code in customer_subscription_created so we can remove that from the flow and IF NOT document better why it has to be this way. It's getting a little complicated to look at in the code, so I need to better document these decisions.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rectWprTKzSGBD4d2?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
