### PR TITLE
Add more cancellation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Environment
 | `ENABLE_SLACK`              |                                          False |
 | `SLACK_API_KEY`             |                                                |
 | `SLACK_CHANNEL`             |                                     #donations |
+| `SLACK_CHANNEL_CANCELLATIONS` |                           #bot-cancellations |
 | `DEFAULT_MAIL_SENDER`       |                                    foo@bar.org |
 | `MAIL_SERVER`               |                                mail.server.com |
 | `MAIL_USERNAME`             |                                                |

--- a/app.json
+++ b/app.json
@@ -189,6 +189,9 @@
     "SLACK_CHANNEL": {
       "required": true
     },
+    "SLACK_CHANNEL_CANCELLATIONS": {
+      "required": true
+    },
     "STRIPE_PRODUCT_SUSTAINING": {
       "required": true
     },

--- a/server/app.py
+++ b/server/app.py
@@ -1649,11 +1649,12 @@ def log_opportunity(contact, payment_intent):
 
 def close_rdo(subscription_id, user_initiated=False, contact=None):
     rdo = RDO.get(subscription_id=subscription_id)
-    rdo_update_details = {"npe03__Open_Ended_Status__c": "Closed", "Cancellation_Date__c": datetime.now()}
+    today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
+    rdo_update_details = {"npe03__Open_Ended_Status__c": "Closed", "Cancellation_Date__c": today}
     if user_initiated:
         rdo_update_details["Cancellation_Method__c"] = "Member Portal"
 
-        contact_update_details = {"Requested_Recurring_Cancellation__c": datetime.now()}
+        contact_update_details = {"Requested_Recurring_Cancellation__c": today}
         Contact.update([contact], contact_update_details)
 
     response = RDO.update([rdo], rdo_update_details)

--- a/server/app.py
+++ b/server/app.py
@@ -1653,7 +1653,7 @@ def close_rdo(subscription_id, user_initiated=False, contact=None):
     if user_initiated:
         rdo_update_details["Cancellation_Method__c"] = "Member Portal"
 
-        contact_update_details = {"Requested_Recurring_Cancellation__c": True}
+        contact_update_details = {"Requested_Recurring_Cancellation__c": datetime.now()}
         Contact.update([contact], contact_update_details)
 
     response = RDO.update([rdo], rdo_update_details)

--- a/server/app.py
+++ b/server/app.py
@@ -39,6 +39,7 @@ from .config import (
     REPORT_URI,
     SENTRY_DSN,
     SENTRY_ENVIRONMENT,
+    SLACK_CHANNEL_CANCELLATIONS,
     STRIPE_PRODUCTS,
     STRIPE_WEBHOOK_SECRET,
     TIMEZONE,
@@ -969,8 +970,7 @@ def payment_intent_succeeded(event):
 def customer_subscription_deleted(event):
     subscription = stripe.Subscription.retrieve(event["data"]["object"]["id"], expand=["customer"])
     customer = subscription["customer"]
-    app.logger.info(f"subscription cancellation_details: {subscription['cancellation_details']}")
-    method = subscription["cancellation_details"].get('comment', 'Staff')
+    method = subscription["cancellation_details"].get('comment') or 'Staff'
     reason = subscription["cancellation_details"].get('reason')
 
     contact = Contact.get(email=customer["email"])
@@ -981,7 +981,7 @@ def customer_subscription_deleted(event):
 
     message = {
         "text": text,
-        "channel": "#tech-test",
+        "channel": SLACK_CHANNEL_CANCELLATIONS,
         "icon_emoji": ":no_good:"
     }
 

--- a/server/app.py
+++ b/server/app.py
@@ -967,7 +967,7 @@ def payment_intent_succeeded(event):
 
 @celery.task(name="app.customer_subscription_deleted")
 def customer_subscription_deleted(event):
-    subscription = stripe.Subscription.retrieve(event["data"]["object"], expand=["customer"])
+    subscription = stripe.Subscription.retrieve(event["data"]["object"]["id"], expand=["customer"])
     customer = subscription["customer"]
     details = subscription["cancellation_details"]
 

--- a/server/app.py
+++ b/server/app.py
@@ -969,6 +969,7 @@ def payment_intent_succeeded(event):
 def customer_subscription_deleted(event):
     subscription = stripe.Subscription.retrieve(event["data"]["object"]["id"], expand=["customer"])
     customer = subscription["customer"]
+    app.logger.info(f"subscription cancellation_details: {subscription['cancellation_details']}")
     method = subscription["cancellation_details"].get('comment', 'Staff')
     reason = subscription["cancellation_details"].get('reason')
 

--- a/server/app.py
+++ b/server/app.py
@@ -1637,7 +1637,7 @@ def log_opportunity(contact, payment_intent):
 
 def close_rdo(subscription_id, user_initiated=False):
     rdo = RDO.get(subscription_id=subscription_id)
-    update_details = {"npe03__Open_Ended_Status__c": "Closed"}
+    update_details = {"npe03__Open_Ended_Status__c": "Closed", "Cancellation_Date__c": datetime.now()}
     if user_initiated:
         update_details["Cancellation_Method__c"] = "Member Portal"
     response = RDO.update([rdo], update_details)

--- a/server/config.py
+++ b/server/config.py
@@ -90,6 +90,7 @@ STRIPE_PRODUCTS = {
 #
 ENABLE_SLACK = bool_env("ENABLE_SLACK")
 SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", "#stripe")
+SLACK_CHANNEL_CANCELLATIONS = os.getenv("SLACK_CHANNEL_CANCELLATIONS", "#tech-test")
 SLACK_API_KEY = os.getenv("SLACK_API_KEY")
 
 ########

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -314,6 +314,11 @@ class SalesforceObject(object):
         self.id = None
         self.sf = SalesforceConnection() if sf_connection is None else sf_connection
 
+    @classmethod
+    def update(cls, obj_list, update_dict, sf_connection=None):
+        sf = SalesforceConnection() if sf_connection is None else sf_connection
+        return sf.updates(obj_list, update_dict)
+
 
 class Opportunity(SalesforceObject, CampaignMixin):
 
@@ -854,11 +859,6 @@ class RDO(SalesforceObject, CampaignMixin):
         )
         update = {"RecordType": {"Name": self.record_type_name}}
         self.sf.updates(self.opportunities(), update)
-
-    @classmethod
-    def update(cls, rdo, update_details, sf_connection=None):
-        sf = SalesforceConnection() if sf_connection is None else sf_connection
-        return sf.updates(rdo, update_details)
 
 
 class Account(SalesforceObject):

--- a/server/static/js/src/entry/account/store/user/index.js
+++ b/server/static/js/src/entry/account/store/user/index.js
@@ -119,6 +119,7 @@ const actions = {
       (state.viewAsEmail && idTokenPayload['https://texastribune.org/is_staff'])) {
       const { accessToken } = rootState.tokenUser;
       const { userId } = getters;
+      updates.userInitiated = !state.viewAsEmail
 
       await axios.patch(
         `${PORTAL_API_URL}persons/${userId}/rdos/close/`,


### PR DESCRIPTION
#### What's this PR do?
It fills in some info on recurring donation cancellations that the membership team have asked for, namely...
* adds a cancel date to the RDO object (no matter what the cause)
* adds a cancel date to the Contact object (when cancelled directly by a member)
* adds a cancel source (either "Member Portal" when triggered directly by member or "Staff" otherwise)
* messages the #bot-cancellations channel when a donation is cancelled

#### Why are we doing this? How does it help us?
This will give more knowledge and awareness around recurring donation cancellation patterns and habits.

#### How should this be manually tested?
* On staging, add a new donation [here](https://donations-testing.herokuapp.com/donate) using the email you most often log into the portal with
* On staging, add another new donation using a different email that you don't often use to log into the portal

**Cancelling your own membership:**
* Log into the portal using the same email from step 1 and click memberships
* You should see the donation you made earlier listed, but if not, give it some time and refresh after a bit
* Cancel the donation you made earlier (no need to fill out the reason form)
* Bounce over to salesforce and find the recurring donation you just cancelled (quickest way is to search by the email you used and a table of recurring donations tied to that email should be the first thing you see)
* When you're on that record's page, you should see two fields...
    * "Cancellation Date" should have today's date
    * "Cancellation Method" should say "Member Portal"
* Over in slack land, a message should have populated on the #test-tech channel about the cancellation
 
**Cancelling another member's donation:**
* Still in the membership portal, use the tool that allows you to view as another member and enter the email you used in step 2 (above)
* From here largely follow the same steps for this donation as you did the last one with one caveat...
    * "Cancellation Method" should say "Staff"

#### How should this change be communicated to end users?
We'll let the membership team know when it's done.

#### Are there any smells or added technical debt to note?
There's probably more discussion to be had around the date field on Contact... if a member cancels their donation and a week later gives a new recurring donation, do we need to wipe that field? How about if there are two rdos on one customer record (not likely but can happen)?

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recDfgKWcBEkyfuZH?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
