### PR TITLE
make next opp update less rigid

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -64,6 +64,7 @@ from .util import (
 
 ZONE = timezone(TIMEZONE)
 USE_THERMOMETER = False
+MAX_SYNC_DAYS_DIFFERENCE = 10
 
 DONATION_TYPE_INFO = {
     "membership": {
@@ -1600,9 +1601,9 @@ def update_next_opportunity(opps=[], invoice=None):
 
     next_opp = opps[0]
     next_opp_date = datetime.strptime(next_opp.expected_giving_date, "%Y-%m-%d")
-    charged_on = datetime.fromtimestamp(invoice["effective_at"])
-    days_difference = abs((charged_on - next_opp_date).days)
-    if days_difference > 30:
+    charged_on_date = datetime.fromtimestamp(invoice["effective_at"])
+    days_difference = abs((charged_on_date - next_opp_date).days)
+    if days_difference > MAX_SYNC_DAYS_DIFFERENCE:
         raise Exception(f"""There is a large discrepancy between the charge date of invoice: {invoice["id"]}
                         and the giving date of opp: {next_opp.id} that should be reviewed before further updates.""")
 

--- a/server/app.py
+++ b/server/app.py
@@ -1598,14 +1598,20 @@ def update_next_opportunity(opps=[], invoice=None):
             asc_order=True
         )
 
+    app.logger.info("in here 1")
     next_opp = opps[0]
+    app.logger.info(f"this is the next opp: {opps}")
     next_opp_date = datetime.strptime(next_opp.expected_giving_date, "%Y-%m-%d")
+    app.logger.info("in here 2")
     charged_on = datetime.fromtimestamp(invoice["effective_at"])
+    app.logger.info("in here 3")
     days_difference = abs((charged_on - next_opp_date).days)
+    app.logger.info("in here 4")
     if days_difference > 30:
         raise Exception(f"""There is a large discrepancy between the charge date of invoice: {invoice["id"]}
                         and the giving date of opp: {next_opp.id} that should be reviewed before further updates.""")
 
+    app.logger.info("in here 5")
     transaction_id = invoice["charge"]
     amount = invoice.get("amount_paid", 0) / 100
     charge_details = {
@@ -1614,8 +1620,11 @@ def update_next_opportunity(opps=[], invoice=None):
     }
     if amount:
         charge_details["Amount"] = amount
+    app.logger.info("in here 6")
 
     response = Opportunity.update_stage([next_opp], charge_details)
+    app.logger.info("in here last with response: {response}")
+
 
 
 def log_opportunity(contact, payment_intent):

--- a/server/app.py
+++ b/server/app.py
@@ -1593,16 +1593,19 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
 def update_next_opportunity(opps=[], invoice=None):
     if not opps:
         opps = Opportunity.list(
-            stage_name="Pledged", stripe_subscription_id=invoice["subscription"]["id"]
+            stage_name="Pledged",
+            stripe_subscription_id=invoice["subscription"]["id"],
+            asc_order=True
         )
 
-    charged_on = datetime.fromtimestamp(invoice["effective_at"]).strftime('%Y-%m-%d')
-    opp = [
-        opportunity
-        for opportunity in opps
-        if opportunity.expected_giving_date == charged_on
-    ][0]
-    app.logger.info(f'opps with giving_date today on subscription_id: {opp}')
+    next_opp = opps[0]
+    next_opp_date = datetime.strptime(next_opp.expected_giving_date, "%Y-%m-%d")
+    charged_on = datetime.fromtimestamp(invoice["effective_at"])
+    days_difference = abs((charged_on - next_opp_date).days)
+    if days_difference > 30:
+        raise Exception(f"""There is a large discrepancy between the charge date of invoice: {invoice["id"]}
+                        and the giving date of opp: {next_opp.id} that should be reviewed before further updates.""")
+
     transaction_id = invoice["charge"]
     amount = invoice.get("amount_paid", 0) / 100
     charge_details = {
@@ -1612,7 +1615,7 @@ def update_next_opportunity(opps=[], invoice=None):
     if amount:
         charge_details["Amount"] = amount
 
-    response = Opportunity.update_stage([opp], charge_details)
+    response = Opportunity.update_stage([next_opp], charge_details)
 
 
 def log_opportunity(contact, payment_intent):

--- a/server/app.py
+++ b/server/app.py
@@ -1598,20 +1598,14 @@ def update_next_opportunity(opps=[], invoice=None):
             asc_order=True
         )
 
-    app.logger.info("in here 1")
     next_opp = opps[0]
-    app.logger.info(f"this is the next opp: {opps}")
     next_opp_date = datetime.strptime(next_opp.expected_giving_date, "%Y-%m-%d")
-    app.logger.info("in here 2")
     charged_on = datetime.fromtimestamp(invoice["effective_at"])
-    app.logger.info(f"in here 3 with next_opp_date: {next_opp_date} and charged_on: {charged_on}")
     days_difference = abs((charged_on - next_opp_date).days)
-    app.logger.info(f"in here 4 with days_difference: {days_difference}")
     if days_difference > 30:
         raise Exception(f"""There is a large discrepancy between the charge date of invoice: {invoice["id"]}
                         and the giving date of opp: {next_opp.id} that should be reviewed before further updates.""")
 
-    app.logger.info("in here 5")
     transaction_id = invoice["charge"]
     amount = invoice.get("amount_paid", 0) / 100
     charge_details = {
@@ -1620,11 +1614,8 @@ def update_next_opportunity(opps=[], invoice=None):
     }
     if amount:
         charge_details["Amount"] = amount
-    app.logger.info("in here 6")
 
     response = Opportunity.update_stage([next_opp], charge_details)
-    app.logger.info(f"in here last with response: {response}")
-
 
 
 def log_opportunity(contact, payment_intent):

--- a/server/app.py
+++ b/server/app.py
@@ -1604,9 +1604,9 @@ def update_next_opportunity(opps=[], invoice=None):
     next_opp_date = datetime.strptime(next_opp.expected_giving_date, "%Y-%m-%d")
     app.logger.info("in here 2")
     charged_on = datetime.fromtimestamp(invoice["effective_at"])
-    app.logger.info("in here 3")
+    app.logger.info(f"in here 3 with next_opp_date: {next_opp_date} and charged_on: {charged_on}")
     days_difference = abs((charged_on - next_opp_date).days)
-    app.logger.info("in here 4")
+    app.logger.info(f"in here 4 with days_difference: {days_difference}")
     if days_difference > 30:
         raise Exception(f"""There is a large discrepancy between the charge date of invoice: {invoice["id"]}
                         and the giving date of opp: {next_opp.id} that should be reviewed before further updates.""")
@@ -1623,7 +1623,7 @@ def update_next_opportunity(opps=[], invoice=None):
     app.logger.info("in here 6")
 
     response = Opportunity.update_stage([next_opp], charge_details)
-    app.logger.info("in here last with response: {response}")
+    app.logger.info(f"in here last with response: {response}")
 
 
 

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -387,6 +387,7 @@ class Opportunity(SalesforceObject, CampaignMixin):
         stripe_subscription_id=None,
         stripe_transaction_id=None,
         sf_connection=None,
+        asc_order=False
     ):
 
         # TODO a more generic dserializing method
@@ -410,6 +411,8 @@ class Opportunity(SalesforceObject, CampaignMixin):
                 WHERE Stripe_Customer_ID__c = '{stripe_customer_id}'
                 AND StageName = '{stage_name}'
             """
+        
+        order_by = f"""ORDER BY Expected_Giving_Date__c ASC""" if asc_order else ""
 
         query = f"""
             SELECT
@@ -441,6 +444,7 @@ class Opportunity(SalesforceObject, CampaignMixin):
                 Quarantined__c
             FROM Opportunity
             {where}
+            {order_by}
         """
 
         response = sf.query(query)


### PR DESCRIPTION
#### What's this PR do?
Adds an order_by option to the Opportunity query so that we can easily get the next opp in line (instead of having to be rigid about the date)... also adding a check to make sure the difference between the date on the stripe invoice and the next opp in SF isn't > 30 days (outlier case, but nice to know)

#### Why are we doing this? How does it help us?
Currently we are running into a handful of issues where, for one reason or another, when the charge date is off from the exact date the next opportunity has in salesforce, things break. This should make the process less rigid while also building in a check to make sure the charge date and opp date aren't more than 30 days apart so that nothing wild happens.

#### How should this be manually tested?
Guess what! Stripe clock time again!
* Start a new simulation (call it whatever you like and go with the current date but set the time of day to 11:30 PM)
* Once you're looking at your simulation, add a new user (add dropdown menu halfway down the page)
    * include name, email and currency (USD)
    * the email should be that of a contact you know exists in our sandbox db (i.e. one you've used recently)... stripe clocks don't pass along enough info to salesforce to make a wholly new contact, so we rely on it attaching subscriptions to existing salesforce contacts (found by email)
* Click the new customer and, when on the customer page, add a new payment method (card) using any of the [stripe test cards](https://stripe.com/docs/testing#cards) except for the popular 4242...
    * I have absolutely no clue why, but SEEMINGLY using a different card than 4242 solves the issues we've been running into
* Now add a new subscription (while still on the customer page)
    * Keep the starting date as is (current date by clock)
    * For "Pricing", search for "blast" and pick one of the products listed
    * Choose "Schedule subscription" at bottom of the form
* You should see the new scheduled subscription listed under "Subscriptions" 
* Click on "Advance time" in the simulation toolbar at the top of the page
* Set the clock to the following day at 12:30 AM, then click "Advance"
* Advancing to this time will cause the subscription creation and subscription schedule updated events to send to our web hook
* Now advance a full month ahead on the calendar and set the time to 1:30 AM
* This should trigger the payment_intent.succeeded event which should update the next opportunity in salesforce to the correct amount and the be "Closed Won"
    * this is where the process would previously fail before this code fix
* Not seeing an error in #tech-warnings is a good sign, but to make sure everything worked as expected, search for the recurring donation in our salesforce sandbox using the customer id (it should be the first result you get, but if not, going off of amount/date is helpful)
* Once looking at the recurring donation, click "Related" to see the listing of opportunities and click to see all opps
* The opps should be in descending order, so the bottom two opps should both be marked "Closed Won" (the initial opp was updated when we created the subscription and the second one was updated when we advanced a month)

#### How should this change be communicated to end users?
We can let Morgan know, but no one else is really aware of this issue outside of the engineering team.

#### Are there any smells or added technical debt to note?
This mostly makes things easier, but I'm interested to see if we ever hit the logger warning I added. Technically we shouldn't, but it's there to catch edge cases. Oh, worth it to mention that this might be obsolete once we migrate salesforce to a newer version which updates recurring donations to only be linked to one opp (the next in line). I'm not sure what that will look like though, so we'll cross that bridge when we get there.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/rec5FJVwu32oNgtzK?blocks=hide
