### PR TITLE
update closed lost reason on next opp

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1580,9 +1580,11 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
     if source:
         card = stripe.Customer.retrieve_source(customer_id, source)
     else:
-        customer = stripe.Customer.retrieve(customer_id)
-        card = customer.sources.retrieve(customer.sources.data[0].id)
-        app.logger.info(f"in here too! {card}")
+        customer = stripe.Customer.retrieve(customer_id, expand=["sources"])
+        app.logger.info(customer)
+        card = customer["sources"]["data"][0]
+        # card = customer.sources.retrieve(customer.sources.data[0].id)
+        # app.logger.info(f"in here too! {card}")
 
     year = card["exp_year"]
     month = card["exp_month"]

--- a/server/app.py
+++ b/server/app.py
@@ -1581,6 +1581,7 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
         card = stripe.Customer.retrieve_source(customer_id, source)
     else:
         customer = stripe.Customer.retrieve(customer_id)
+        app.logger.info(f"in here! {customer.sources.data}")
         card = customer.sources.retrieve(customer.sources.data[0].id)
 
     year = card["exp_year"]

--- a/server/app.py
+++ b/server/app.py
@@ -923,7 +923,7 @@ def customer_subscription_created(event):
     # use that, otherwise retrieve the latest invoice from stripe
     if not subscription["trial_end"] and invoice_status != "draft":
         update_next_opportunity(
-            opps=rdo.opportunities(),
+            opps=rdo.opportunities(ordered_pledges=True),
             invoice=invoice,
         )
 

--- a/server/app.py
+++ b/server/app.py
@@ -1581,8 +1581,8 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
         card = stripe.Customer.retrieve_source(customer_id, source)
     else:
         customer = stripe.Customer.retrieve(customer_id)
-        app.logger.info(f"in here! {customer.sources.data}")
         card = customer.sources.retrieve(customer.sources.data[0].id)
+        app.logger.info(f"in here too! {card}")
 
     year = card["exp_year"]
     month = card["exp_month"]

--- a/server/app.py
+++ b/server/app.py
@@ -1667,7 +1667,7 @@ def close_rdo(subscription_id, method=None, contact=None, reason=None):
         return None
 
     try:
-        next_opp = rdo.opportunities(order_pledges=True)[0]
+        next_opp = rdo.opportunities(ordered_pledges=True)[0]
     except Exception:
         app.logger.error(f"The next pledged opportunity for recurring donation {rdo.id} was not found and the Salesforce cancellation process was halted.")
         return None

--- a/server/app.py
+++ b/server/app.py
@@ -1534,6 +1534,7 @@ def get_account(customer):
 
 
 def log_rdo(type=None, contact=None, account=None, subscription=None):
+    app.logger.info(f"printing out the sub here for clarity: {subscription}")
     sub_meta = subscription["metadata"]
     sub_plan = subscription["plan"]
     customer_id = subscription["customer"]
@@ -1580,9 +1581,8 @@ def log_rdo(type=None, contact=None, account=None, subscription=None):
     if source:
         card = stripe.Customer.retrieve_source(customer_id, source)
     else:
-        customer = stripe.Customer.retrieve(customer_id, expand=["sources"])
-        app.logger.info(customer)
-        card = customer["sources"]["data"][0]
+        customer = stripe.Customer.retrieve(customer_id)
+        card = stripe.Customer.retrieve_source(customer_id, customer["invoice_settings"]["default_payment_method"])
         # card = customer.sources.retrieve(customer.sources.data[0].id)
         # app.logger.info(f"in here too! {card}")
 

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -743,7 +743,14 @@ class RDO(SalesforceObject, CampaignMixin):
     # has changed? The opportunities themselves may've changed even when the RDO hasn't so
     # this may not be doable.
 
-    def opportunities(self):
+    def opportunities(self, ordered_pledges=False):
+        order_by = ""
+        if ordered_pledges:
+            order_by = f"""
+                AND StageName = 'Pledged'
+                ORDER BY Expected_Giving_Date__c ASC
+                """
+
         query = f"""
             SELECT Id, Amount, Name, Stripe_Customer_ID__c,
             Stripe_Subscription_Id__c, Description, Stripe_Agreed_to_pay_fees__c,
@@ -754,6 +761,7 @@ class RDO(SalesforceObject, CampaignMixin):
             Stripe_Card_Expiration__c, Stripe_Card_Last_4__c, Quarantined__c
             FROM Opportunity
             WHERE npe03__Recurring_Donation__c = '{self.id}'
+            {order_by}
         """
         # TODO must make this dynamic
         response = self.sf.query(query)


### PR DESCRIPTION
#### What's this PR do?
* adds an order_by to the opportunities func on RDO for ease of grabbing the next pledged opp
* updates the stage and closed lost reason on the next pledged opp
* adds better error handling and messaging

#### Why are we doing this? How does it help us?
The salesforce side is expecting a closed lost reason for cancelled subscriptions due to payment failures.

#### How should this be manually tested?
* Start a [new stripe clocks simulation](https://dashboard.stripe.com/test/billing/subscriptions/test-clocks) (call it whatever you like and go with the current date)
* <img width="848" alt="Screen Shot 2024-02-26 at 10 18 17 AM" src="https://github.com/texastribune/donations/assets/88053677/5e68137f-0302-43ae-8b85-21507a351d92">
* Once you're looking at your simulation, add a new user (add dropdown menu halfway down the page)
* <img width="1050" alt="Screen Shot 2024-02-26 at 10 21 28 AM" src="https://github.com/texastribune/donations/assets/88053677/831cefc8-6d87-480e-a0e9-01eecc58a4df">
    * include name, email and currency (USD)
    * make sure the email is one you've previously used on donations staging (you can use "matthew.mccrary@texastribune.org" or "ashleyhebler+2-22-24@gmail.com" if you're just sitting there staring at this line)
    * <img width="718" alt="Screen Shot 2024-02-26 at 10 21 48 AM" src="https://github.com/texastribune/donations/assets/88053677/cee9cc65-4268-4954-bedf-1355cb758406">
        * context -> stripe clocks doesn't give enough information to the salesforce side to create a brand new contact, though it does give enough info to create a brand new subscription... ergo, using an email that is already tied to a contact in our salesforce sandbox allows a new rdo to be added to an existing contact (otherwise this step fails)
* Now click on the newly created customer and add a new subscription
* <img width="697" alt="Screen Shot 2024-02-26 at 10 39 15 AM" src="https://github.com/texastribune/donations/assets/88053677/67575533-4490-4326-bff4-fd352e23ebb8">
    * Keep the starting date as is (current date by clock)
    * For "Pricing", search for "blast" and pick one of the products listed
    * <img width="1141" alt="Screen Shot 2024-02-26 at 10 24 53 AM" src="https://github.com/texastribune/donations/assets/88053677/60fac61a-382d-4736-8c79-984a8aa92863">
    * IMPORTANT: in the "Subscription Settings - Payment" area, add a new payment method (card) using any of the [stripe test cards](https://stripe.com/docs/testing#cards)
        * if you see the option to set the card as Default, do so
        * <img width="918" alt="Screen Shot 2024-02-22 at 12 13 03 PM" src="https://github.com/texastribune/donations/assets/88053677/51034368-4892-4c37-8030-bfc7ac03123a">
    * Choose "Schedule subscription" at bottom of the form
* You should see the new scheduled subscription listed under "Subscriptions"

* Since we've had issues with stripe clocks to this point, I would check [Salesforce](https://texastribune--2023stripe.sandbox.lightning.force.com/lightning/page/home) to make sure the subscription synced over there as an RDO (doing a search by the email you used or the stripe customer_id is probably the quickest way to find the RDO, and the RDO title will include the time, so go off of that to confirm you're looking at the right one)
* <img width="1045" alt="Screen Shot 2024-02-26 at 10 31 01 AM" src="https://github.com/texastribune/donations/assets/88053677/09d6632a-b17c-4d34-8971-9a1a99b0d9a1">
* Found it? Take a breath. You're through the most annoying phase of this (I think 😅)

* Back in stripe, find the subscription you just created and click on "Update Subscription" from the drop-down menu
* <img width="692" alt="Screen Shot 2024-02-22 at 12 23 18 PM" src="https://github.com/texastribune/donations/assets/88053677/113a6248-744e-4f31-a972-56ae5aa89e59">
* Find the "Subscription Settings - Payment" section again and click to edit the payment
* Choose to add a new card and use the exact card number in the following screenshot (this one in particular is meant to pass stripe's initial check during payment update but purposefully fails at time of charge) and make sure "Set as customer's new default" is checked
* <img width="870" alt="Screen Shot 2024-02-22 at 12 27 21 PM" src="https://github.com/texastribune/donations/assets/88053677/e4f79a1c-2c12-4c58-8875-44c8d0d6b2d9">
* After saving, you can refresh the page to make sure the new card is set as "Default" in the "Payments Section" of the customer page
* <img width="688" alt="Screen Shot 2024-02-22 at 12 27 54 PM" src="https://github.com/texastribune/donations/assets/88053677/706ccefc-b94d-4c2b-b8bd-4eb8109890a0">
* Now, click on "Advance time" in the simulation toolbar at the top of the page
* Set the clock to a month and three+ hours in advance of whatever the clock currently says, then click "Advance"
* After advancing to this time, you should see the subscription is in a "Past due" status and the most recent Payment is marked "Failed". This is basically the first time the charge was attempted and failed.
* Because the charge is retried two more times over a span of nine days, now advance two weeks ahead (you could instead advance by nine+ days, but advancing two weeks ahead is just easier to see on the calendar)
* This should trigger the customer.subscription.deleted event which should both close the recurring donation AND update the next opportunity to have a Closed Lost Reason
    * From the recurring donation, click "Related" to get a list of the opportunities and click to see all opps (besides the very last opp you see, they should all be marked "Closed Lost" at this point)
    * <img width="621" alt="Screen Shot 2024-02-26 at 10 52 56 AM" src="https://github.com/texastribune/donations/assets/88053677/4fe7bc5a-1728-4782-a26e-bbf934769db7">
    * Click on the one closest from the bottom marked "Closed Lost"
    * <img width="891" alt="Screen Shot 2024-02-26 at 10 53 19 AM" src="https://github.com/texastribune/donations/assets/88053677/c8ae26c9-d150-4b5e-bca7-98b77dadc1fe">
    * Now, looking at the opportunity, click "Details" and it's easiest to do a ctrl-f for "Closed Lost Reason" from here, because this page has a lot going on
    * <img width="715" alt="Screen Shot 2024-02-26 at 10 53 40 AM" src="https://github.com/texastribune/donations/assets/88053677/ac1011d8-ec98-4e05-acdc-a79c514941f5">
    * The "Closed Lost Reason" field should be filled (likely "payment_failed")
    * <img width="933" alt="Screen Shot 2024-02-26 at 10 54 05 AM" src="https://github.com/texastribune/donations/assets/88053677/a3c599e5-a7cd-4685-bb61-52a06e691413">

#### How should this change be communicated to end users?
We'll update the #project-donations channel where this was initially requested.

#### Are there any smells or added technical debt to note?
Not really. Some of this will code will be made moot when we migrate to the newer version of salesforce because an rdo will ONLY point to the next pledged opp, but most of it will still be applicable. Also, if it proves fruitful, we could shore up a more human friendly message about why the charge failed, though that would probably be more helpful in slack than in salesforce. (FWIW this info stays available in stripe, so we're not losing it by not syncing it t SF)

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recHELo7XtiYHnJqA?blocks=hide
