### PR TITLE
hottfix: adds ordering option for an rdo's opps

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -923,7 +923,7 @@ def customer_subscription_created(event):
     # use that, otherwise retrieve the latest invoice from stripe
     if not subscription["trial_end"] and invoice_status != "draft":
         update_next_opportunity(
-            opps=rdo.opportunities(),
+            opps=rdo.opportunities(ordered_pledges=True),
             invoice=invoice,
         )
 

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -747,7 +747,14 @@ class RDO(SalesforceObject, CampaignMixin):
     # has changed? The opportunities themselves may've changed even when the RDO hasn't so
     # this may not be doable.
 
-    def opportunities(self):
+    def opportunities(self, ordered_pledges=False):
+        order_by = ""
+        if ordered_pledges:
+            order_by = f"""
+                AND StageName = 'Pledged'
+                ORDER BY Expected_Giving_Date__c ASC
+                """
+        
         query = f"""
             SELECT Id, Amount, Name, Stripe_Customer_ID__c,
             Stripe_Subscription_Id__c, Description, Stripe_Agreed_to_pay_fees__c,
@@ -758,6 +765,7 @@ class RDO(SalesforceObject, CampaignMixin):
             Stripe_Card_Expiration__c, Stripe_Card_Last_4__c, Quarantined__c
             FROM Opportunity
             WHERE npe03__Recurring_Donation__c = '{self.id}'
+            {order_by}
         """
         # TODO must make this dynamic
         response = self.sf.query(query)


### PR DESCRIPTION
#### What's this PR do?
* adds ordering option for opps grabbed by an rdo
* utilizes this option when grabbing an rdo's opps in the customer_subscription_created func

#### Why are we doing this? How does it help us?
Hottfix for a bug popping up randomly when the first opp in the opps list retrieved for an rdo is NOT the next opp chronologically. This adds ordering that fixes that.