### PR TITLE
Revert "Border coverage 2024"

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -63,7 +63,7 @@ from .util import (
 )
 
 ZONE = timezone(TIMEZONE)
-USE_THERMOMETER = True
+USE_THERMOMETER = False
 MAX_SYNC_DAYS_DIFFERENCE = 10
 
 DONATION_TYPE_INFO = {

--- a/server/static/js/src/entry/donate/router.js
+++ b/server/static/js/src/entry/donate/router.js
@@ -3,8 +3,9 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 import RouteHandler from '../../RouteHandler.vue';
-// import Thermometer from './Thermometer.vue';
-import ThermometerMinimal from './ThermometerMinimal.vue';
+import Thermometer from './Thermometer.vue';
+// use this for a simple number output - See PR #1178
+// import ThermometerMinimal from './ThermometerMinimal.vue';
 import TopForm from './TopForm.vue';
 import mergeValuesIntoStartState from '../../utils/merge-values-into-start-state';
 import sanitizeParams from '../../utils/sanitize-params';
@@ -98,7 +99,7 @@ function bindRouterEvents(router, routeHandler, store) {
     // based on the constant USE_THERMOMETER in app.py
     const thermometerEl = document.getElementById('thermometer');
     if (thermometerEl) {
-      const thermometer = new Vue({ ...ThermometerMinimal, store });
+      const thermometer = new Vue({ ...Thermometer, store });
       thermometer.$mount(thermometerEl)
     }
   });

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-border.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
@@ -18,9 +18,9 @@
 {% endblock %}
 
 {% block content %}
-  {# {% if use_thermometer %}
+  {% if use_thermometer %}
     {% include "includes/thermometer.html" %}
-  {% endif %} #}
+  {% endif %}
 
   <section class="splash splash--tall grid_separator--l">
     <div class="grid_container grid_padded--xl">
@@ -41,11 +41,9 @@
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
             <div id="app" style="display:none;"></div>
-            <div class="c-message grid_separator has-text-gray-dark t-size-s t-links-underlined">
-               <p class="has-b-btm-marg">Texas Tribune members are rallying around the Tribune’s border coverage. Our new crowdfunding goal for Friday is $20,000. We’re tripling our reporting presence on the border during this crucial moment and we need your support. Donate today because we need Texas journalists doing original reporting from border communities.
-                <div id="thermometer"></div>
-                </p>
-            </div>
+            <!--<div class="c-message grid_separator has-text-gray-dark t-size-s">
+               <p>Use this area for timely messaging (eg. membership drive, giving Tuesday, etc.)</p>
+            </div>-->
             <h2 class="grid_separator link--teal">Become a Texas Tribune Member today</h2>
             <!-- where the form attaches -->
             <div id="top-form"></div>


### PR DESCRIPTION
#### What's this PR do?

- Removes the fund raiser messaging
- Keeps the minimal thermometer for potential future use


#### Why are we doing this? How does it help us?

This campaign ends after 4/19

#### How should this be manually tested?

See that the donations page is back to normal

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

Nah

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwb2L2CHc4ZWqkC5/recKyxS2nxqcvK7p6?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *Deploy Saturday 4/20*
