### PR TITLE
fix stripe missing card issue during sync

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1580,15 +1580,19 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
     else:
         card = stripe.Customer.retrieve_source(customer_id, customer["invoice_settings"]["default_payment_method"])
 
-    year = card["exp_year"]
-    month = card["exp_month"]
-    day = calendar.monthrange(year, month)[1]
+    year = card.get("exp_year", None)
+    month = card.get("exp_month", None)
+    if year and month:
+        day = calendar.monthrange(year, month)[1]
+        rdo.stripe_card_expiration = f"{year}-{month:02d}-{day:02d}"
 
-    rdo.stripe_card_expiration = f"{year}-{month:02d}-{day:02d}"
-    rdo.stripe_card_brand = card["brand"]
-    rdo.stripe_card_last_4 = card["last4"]
+    rdo.stripe_card_brand = card.get("brand", None)
+    rdo.stripe_card_last_4 = card.get("last4", None)
 
     rdo.save()
+
+    if not rdo.stripe_card_expiration or not rdo.stripe_card_last_4:
+        app.logger.error(f'Stripe was not able to provide the full card information for subscription {subscription["id"]}.')
 
     return rdo
 


### PR DESCRIPTION
#### What's this PR do?
Stops assuming that stripe properly passes back a card at time of RDO creation.

#### Why are we doing this? How does it help us?
With the current way this is set up, instances where stripe DOESN'T properly send back the card info result in the rdo not being created at all. Longterm, we need to figure out why this data doesn't reliably come through, but in the meantime, rdo should always get created and we can throw up an error message that lets us know we need to update the card info manually.

#### How should this be manually tested?
Huh... good question. Since I can't reliably get stripe to not send card info, I don't really have a good way of testing this, besides getting it into production and rerunning a recent subscription that didn't sync properly when getting to this step because the card data can't be found.

#### How should this change be communicated to end users?
We can notify Morgan about this fix.

#### Are there any smells or added technical debt to note?
This missing card thing seems to keep happening, which is weird because the charges are going through, so the card is there... I need to play around with stripe some (maybe even more fun with CLOCKS) to see why this info is missing sometimes (likely the timing is my guess) so there should be a future pr that has a better source for this data BUT, either way, good to make this a get instead of always assuming the data will be there.

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
