### PR TITLE
Clarify Donation Frequency

### DIFF
--- a/server/static/js/src/connected-elements/FrequencyDisplay.vue
+++ b/server/static/js/src/connected-elements/FrequencyDisplay.vue
@@ -28,7 +28,7 @@ export default {
       });
 
       if (installmentPeriod === 'None') return '';
-      return '/' + installmentPeriod.toLowerCase();
+      return `/${installmentPeriod.toLowerCase()}`;
     },
   },
 

--- a/server/static/js/src/connected-elements/FrequencyDisplay.vue
+++ b/server/static/js/src/connected-elements/FrequencyDisplay.vue
@@ -1,0 +1,37 @@
+<template>
+  <div aria-live="polite" class="has-text-gray-dark">
+    {{ installmentPeriod }}
+  </div>
+</template>
+
+<script>
+import updateValue from './mixins/update-value';
+import getValue from './mixins/get-value';
+
+export default {
+  name: 'FrequencyDisplay',
+
+  mixins: [updateValue, getValue],
+
+  props: {
+    storeModule: {
+      type: String,
+      required: true,
+    },
+  },
+
+  computed: {
+    installmentPeriod() {
+      const installmentPeriod = this.getValue({
+        storeModule: this.storeModule,
+        key: 'installment_period',
+      });
+
+      if (installmentPeriod === 'None') return '';
+      return '/' + installmentPeriod.toLowerCase();
+    },
+  },
+
+
+};
+</script>

--- a/server/static/js/src/connected-elements/TextInput.vue
+++ b/server/static/js/src/connected-elements/TextInput.vue
@@ -1,18 +1,23 @@
 <template>
   <div :class="classesWithValidation">
     <label v-if="hasLabel" :for="connector">{{ labelText }}</label>
-    <input
-      :id="connector"
-      :aria-label="ariaLabel"
-      :aria-invalid="!isValid ? true : false"
-      :aria-required="required"
-      :value="value"
-      :name="name"
-      :placeholder="placeholder"
-      :type="type"
-      :inputmode="inputmode"
-      @input="updateSingleValue($event.target.value)"
-    />
+    <div :class="{ 'c-freq' : showFrequency }">
+      <input
+        :id="connector"
+        :aria-label="ariaLabel"
+        :aria-invalid="!isValid ? true : false"
+        :aria-required="required"
+        :value="value"
+        :name="name"
+        :placeholder="placeholder"
+        :type="type"
+        :inputmode="inputmode"
+        @input="updateSingleValue($event.target.value)"
+      />
+      <div v-if="showFrequency" class="c-freq__label">
+        <frequency-display :store-module="storeModule" />
+      </div>
+    </div>
     <p v-if="showError && !isValid" role="alert">{{ message }}</p>
   </div>
 </template>
@@ -20,9 +25,14 @@
 <script>
 import connectedElement from './mixins/connected-element';
 import labelConnector from './mixins/label-connector';
+import FrequencyDisplay from './FrequencyDisplay.vue';
 
 export default {
   name: 'TextInput',
+
+  components: {
+    FrequencyDisplay,
+  },
 
   mixins: [connectedElement, labelConnector],
 
@@ -55,6 +65,12 @@ export default {
     inputmode: {
       type: String,
       default: null,
+      required: false,
+    },
+
+    showFrequency: {
+      type: Boolean,
+      default: false,
       required: false,
     },
   },

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -25,8 +25,8 @@
       </div>
     </div>
 
-    <div class="grid_row grid_separator--xs">
-      <div class="col">
+    <div class="grid_row grid_wrap--s grid_separator grid_align--end grid_gap">
+      <div class="col_7">
         <text-input
           :store-module="storeModule"
           :show-error="showErrors"
@@ -37,13 +37,10 @@
           inputmode="decimal"
         />
       </div>
-    </div>
-
-    <div class="grid_row grid_separator">
-      <div class="col">
+      <div class="col_5">
         <p class="subtext">
           For three-year commitments of $1,000 or more, join our
-          <a href="/circle">Circle Membership program</a>.
+          <a class="l-display-ib" href="/circle">Circle Membership program</a>.
         </p>
       </div>
     </div>

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -30,6 +30,7 @@
         <text-input
           :store-module="storeModule"
           :show-error="showErrors"
+          :show-frequency="true"
           label-text="amount* ($)"
           base-classes="form__text form__text--heavy"
           name="amount"

--- a/server/static/sass/6-components/_forms.scss
+++ b/server/static/sass/6-components/_forms.scss
@@ -199,3 +199,21 @@
 .grecaptcha-badge {
   visibility: hidden;
 }
+
+
+// Frequency display
+.c-freq {
+  position: relative;
+
+  input {
+    // cushion for the frequency display
+    padding-right: 100px;
+  }
+
+  &__label {
+    position: absolute;
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/server/static/sass/7-utilities/_grid.scss
+++ b/server/static/sass/7-utilities/_grid.scss
@@ -301,3 +301,11 @@
 .grid_separator--extra {
   margin: $size-b*4 0;
 }
+
+.grid_align--end {
+  align-items: flex-end;
+}
+
+.grid_gap {
+  gap: $size-xxxs;
+}


### PR DESCRIPTION
#### What's this PR do?

Inserts the frequency into the amount text field

#### Why are we doing this? How does it help us?

Donors will inadvertently give a monthly donation bc the page auto selects on that. This leads to frustration later when the next month rolls around. To reduce this, we're making that frequency selection more apparent

| Before | After |
|--------|--------|
| ![TexasTribune Donation (1)](https://github.com/texastribune/donations/assets/2974713/72082974-0486-49c3-a9cd-0d223fc29ac4) | ![Donations Testing Donate](https://github.com/texastribune/donations/assets/2974713/41f9f3ae-6afd-43ce-b89e-563c07cb5dc0) |


#### How should this be manually tested?

This is live on staging. We should make sure nothing about this change impacts submitting a donation. I checked this on my own but another set of eyes doesn't hurt!


#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

I might've committed Vue bads, but I tried to follow the patterns a saw. Such a delightful framework!

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwb2L2CHc4ZWqkC5/recOUhlQuiJALs5bG?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [x] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *Fix tests*
