### PR TITLE
fix unsubscriptable opportunity bug

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1662,7 +1662,7 @@ def log_opportunity(contact, payment_intent):
     opportunity.save()
 
     if not opportunity.stripe_card_expiration or not opportunity.stripe_card_last_4:
-        app.logger.error(f'Stripe was not able to provide the full card information for opportunity {opportunity["id"]}.')
+        app.logger.error(f'Stripe was not able to provide the full card information for opportunity {opportunity.id}.')
 
     return opportunity
 


### PR DESCRIPTION
#### What's this PR do?
treats the opportunity object like an object instead of a dict

#### Why are we doing this? How does it help us?
the other way was breaking

#### How should this be manually tested?
Another hard one to test. I can rerun the push from stripe for a particular event that broke due to this bug and make sure it gets through the syncing flow as expected.

#### How should this change be communicated to end users? 
N/A

#### Are there any smells or added technical debt to note?
N/A

#### What are the relevant tickets?
N/A
