### PR TITLE
Add event syncer

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1549,19 +1549,19 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
     sub_meta = subscription["metadata"]
     sub_plan = subscription["plan"]
     customer_id = subscription["customer"]
-    trial_end = subscription["trial_end"]
+    start_date = subscription["start_date"]
     donation_type_info = DONATION_TYPE_INFO[type]
     installment_period = "yearly" if sub_plan["interval"] == "year" else "monthly"
 
     if type == "business_membership" and account:
-        rdo = RDO(account=account)
+        rdo = RDO(account=account, date=start_date)
         year = datetime.now(tz=ZONE).strftime("%Y")
         rdo.name = f"{year} Business {account.name} Recurring"
         rdo.record_type_name = "Business Membership"
         rdo.installments = None
 
     else:
-        rdo = RDO(contact=contact, date=trial_end)
+        rdo = RDO(contact=contact, date=start_date)
         rdo.installments = None
         if type == "circle":
             rdo.installments = 36 if sub_plan["interval"] == "month" else 3

--- a/server/app.py
+++ b/server/app.py
@@ -888,7 +888,7 @@ def customer_subscription_created(subscription_id):
 
     invoice_status = invoice["status"]
     if invoice_status == "open":
-        raise Exception(f"Subscription {subscription["id"]} was created but its first invoice is still open.\
+        raise Exception(f"Subscription {subscription['id']} was created but its first invoice is still open.\
                         Please follow up with the subscription to proceed.")
     customer = stripe.Customer.retrieve(subscription["customer"])
     contact = get_contact(customer)

--- a/server/app.py
+++ b/server/app.py
@@ -1146,6 +1146,12 @@ def stripehook():
 
     app.logger.info(f"Received event: id={event.id}, type={event.type}")
 
+    process_stripe_event(event)
+
+    return "Success", 200
+
+
+def process_stripe_event(event):
     # setting celery's delay on these keeps the stripe call from erroring out
     if event.type == "customer.source.updated":
         customer_source_updated.delay(event)
@@ -1161,7 +1167,15 @@ def stripehook():
     if event.type == "subscription_schedule.updated":
         subscription_schedule_updated.delay(event)
 
-    return "Success", 200
+    return True
+
+
+def sync_stripe_event(event):
+    stripe_event = stripe.Event.retrieve(event)
+
+    process_stripe_event(stripe_event)
+
+    return stripe_event
 
 
 # this is just a temp func version of a piece of add_donation we're

--- a/server/app.py
+++ b/server/app.py
@@ -1145,19 +1145,19 @@ def stripehook():
 
 def process_stripe_event(event):
     event_type = event["type"]
-    event_object_id = event["data"]["object"]["id"]
+    event_object = event["data"]["object"]
     # setting celery's delay on these keeps the stripe call from erroring out
     if event_type == "customer.source.updated":
         customer_source_updated.delay(event)
     if event_type == "payout.paid":
         payout_paid.delay(event)
     if event_type == "customer.subscription.created":
-        customer_subscription_created.delay(event_object_id)
+        customer_subscription_created.delay(event_object["id"])
     if event_type == "payment_intent.succeeded":
-        payment_intent_succeeded.delay(event_object_id)
+        payment_intent_succeeded.delay(event_object["id"])
     if event_type == "customer.subscription.deleted":
         app.logger.info(f"subscription deleted event: {event}")
-        customer_subscription_deleted.delay(event_object_id)
+        customer_subscription_deleted.delay(event_object["id"])
     if event_type == "subscription_schedule.updated":
         subscription_schedule_updated.delay(event)
 

--- a/server/app.py
+++ b/server/app.py
@@ -1144,22 +1144,21 @@ def stripehook():
 
 
 def process_stripe_event(event):
+    event_type = event["type"]
+    event_object_id = event["data"]["object"]["id"]
     # setting celery's delay on these keeps the stripe call from erroring out
-    if event.type == "customer.source.updated":
+    if event_type == "customer.source.updated":
         customer_source_updated.delay(event)
-    if event.type == "payout.paid":
+    if event_type == "payout.paid":
         payout_paid.delay(event)
-    if event.type == "customer.subscription.created":
-        subscription_id = event["data"]["object"]["id"]
-        customer_subscription_created.delay(subscription_id)
-    if event.type == "payment_intent.succeeded":
-        payment_intent_id = event["data"]["object"]["id"]
-        payment_intent_succeeded.delay(payment_intent_id)
-    if event.type == "customer.subscription.deleted":
+    if event_type == "customer.subscription.created":
+        customer_subscription_created.delay(event_object_id)
+    if event_type == "payment_intent.succeeded":
+        payment_intent_succeeded.delay(event_object_id)
+    if event_type == "customer.subscription.deleted":
         app.logger.info(f"subscription deleted event: {event}")
-        subscription_id = event["data"]["object"]["id"]
-        customer_subscription_deleted.delay(subscription_id)
-    if event.type == "subscription_schedule.updated":
+        customer_subscription_deleted.delay(event_object_id)
+    if event_type == "subscription_schedule.updated":
         subscription_schedule_updated.delay(event)
 
     return True


### PR DESCRIPTION
#### What's this PR do?
Adds a callable function that takes an event id, grabs the event object from stripe and passes it through the usual stripe -> SF sync. Also added the ability to pass in a subscription id or payment intent id to the webhook function that handle those, in the case where the event mentioned above is out of retention (stripe only has a 30 day retention policy for events for some reason).

#### Why are we doing this? How does it help us?
In cases where events crashed out of the stripe->SF sync flow, we can use these tools to still push that info to SF, keeping every donation logged.

#### How should this be manually tested?
Test out a few regular gifts
1) make sure they show up on slack
2) make sure they show up on salesforce

After this, turn off the webhook by...
1) In the stripe dashboard, make sure you're in test mode by toggling it in the upper right-hand corner
    a) extremely important... if you do the next steps and you're NOT in test mode, the sync from stripe to salesforce will effectively be broken (at least temporarily)
2) Click on the "Developers" button just to the left of the test mode toggle
3) Click on the "Webhooks" tab
4) Click on the url listed under "Hosted Endpoints"
5) Click on the menu button on the right-hand side of the page (an ellipses) and choose "Disable..."
    a) This breaks the connection between donations given through staging and the sf db for staging
6) Make another donation
7) Find the donation on stripe by going to the Payments section (still in test mode) and clicking the first entry
8) Copy the customer id on the right of the page and search for it in salesforce
    a) You shouldn't be able to find anything
9) Copy the event id (in the url)
9) Visit our heroku setup for donations-testing
10) On the right hand side of the dashboard click the "More" dropdown and choose "Run console"
    * <img width="496" alt="Screen Shot 2024-05-28 at 12 10 43 PM" src="https://github.com/texastribune/donations/assets/88053677/61311462-a493-4be8-bf52-dad08bbc73c0">
11) When the heroku console is pulled up, run "flask --app server shell" which drops you into the flask shell
12) Run "from server.app import sync_stripe_event"
13) Run "sync_stripe_event(event_id)" (using the event id you copied earlier)
14) Check back on the salesforce side, search for the customer id again and now you should see the recurring donation listed

#### How should this change be communicated to end users?
We can let Morgan know that we're ready to fix any missing donations.

#### Are there any smells or added technical debt to note?
One thing to note is that it would be nice to be able to call the new function from server.util instead of server.app, but that would mean bringing several other functions with it to util.py (pretty much all of the new functions written last year in the transaction to stripe subscriptions). I started toying around with this, but then it ended up being over-complicated for the task at hand so I pulled back and kept this one more simple.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recUzjSnuXgxRUTug?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
