### PR TITLE
"Reason" query param

### DIFF
--- a/server/static/js/src/entry/donate/router.js
+++ b/server/static/js/src/entry/donate/router.js
@@ -32,6 +32,7 @@ function createInitialFormState(queryParams) {
     email = '',
     zipcode = '',
     code = '',
+    reason = '',
   } = cleanParams;
   let amount;
   let installmentPeriod;
@@ -69,6 +70,7 @@ function createInitialFormState(queryParams) {
     campaign_id: campaignId,
     referral_id: referralId,
     installment_period: installmentPeriod,
+    reason: reason,
   });
 }
 

--- a/server/static/js/src/entry/donate/router.js
+++ b/server/static/js/src/entry/donate/router.js
@@ -64,13 +64,13 @@ function createInitialFormState(queryParams) {
   return mergeValuesIntoStartState(BASE_FORM_STATE, {
     amount,
     zipcode,
+    reason,
     first_name: firstName,
     last_name: lastName,
     stripeEmail: email,
     campaign_id: campaignId,
     referral_id: referralId,
     installment_period: installmentPeriod,
-    reason: reason,
   });
 }
 


### PR DESCRIPTION
#### What's this PR do?

Adds the value of "reason" to the form if passed in a query param

<img width="704" alt="Screenshot 2024-06-20 at 4 30 56 PM" src="https://github.com/texastribune/donations/assets/2974713/8946c59d-b056-4c0d-b9fc-d34ded66cca5">


#### Why are we doing this? How does it help us?

This is useful for special donations that need to be classified consistently

#### How should this be manually tested?

Confirm `http://local.texastribune.org/donate?reason=foo` inputs `foo` into the "I'm giving because" field

#### How should this change be communicated to end users?

I'll let the development team know

#### Are there any smells or added technical debt to note?

I don't think so. This was a backlogged item from last year and when I re-looked into it I realized it was comically easy. Made me wonder if I was missing something

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viw2eOTqOWglhM7UI/recQdSKsn2hErH1YG

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
