### PR TITLE
update to include payment_method for card lookup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1583,8 +1583,7 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
     #these nested gets hit three separate fields in order to try and get a card to lookup
     source = subscription.get(
         "default_source", subscription.get(
-            "default_payment_method", customer["invoice_settings"].get(
-                "default_payment_method", None)))
+            "default_payment_method", customer["invoice_settings"]["default_payment_method"] if customer else None))
 
     # attempt retrieving a card as a source and if that errors try as a payment_method
     try:

--- a/server/app.py
+++ b/server/app.py
@@ -1435,7 +1435,7 @@ def create_subscription(donation_type=None, customer=None, form=None, quarantine
             end_behavior="cancel",
             phases=[{
                 "description": donation_type_info["description"],
-                "default_payment_method": source["id"],
+                "default_source": source["id"],
                 "items": [{
                     "price": price
                 }],
@@ -1591,7 +1591,8 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
         card = stripe.Customer.retrieve_source(customer_id, source)
     except:
         try:
-            card = stripe.PaymentMethod.retrieve(source)
+            payment_method = stripe.PaymentMethod.retrieve(source)
+            card = payment_method["card"]
         except:
             app.logger.error(f'Stripe was not able to provide the full card information for subscription {subscription["id"]}.')
 

--- a/server/app.py
+++ b/server/app.py
@@ -1435,7 +1435,7 @@ def create_subscription(donation_type=None, customer=None, form=None, quarantine
             end_behavior="cancel",
             phases=[{
                 "description": donation_type_info["description"],
-                "default_source": source["id"],
+                "default_payment_method": source["id"],
                 "items": [{
                     "price": price
                 }],


### PR DESCRIPTION
#### What's this PR do?
* cleans up initial grab for card id
* tries to retrieve card as source then falls back to retrieving as payment_method

#### Why are we doing this? How does it help us?
Some cards come through as payment_methods, so we need to be able to handle those properly or we won't be able to consistently send card date to salesforce.

#### How should this be manually tested?
Give a donation on staging.
Ensure that a subscription is created stripe side.
Ensure that that data has synced to salesforce.
Go through the same process with a circle donation (since I made a very minor update there)
^ this makes sure donations are still working as expected... to make sure payment_methods are working now, I'll have to try resending a record that has a payment_method (we have one on the "need to sync" list) when in production

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
I still don't have a great grasp of why some cards only show up as payment_methods vs. sources... I think this gets around that because at the end of the day we only need to be able to grab the card data and save it to salesforce, but it might be worth investigating if we find the time (ha).

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recaEuD9FgVGheXYr?blocks=hide
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recSKyrbd2uVxiTgK?blocks=hide
