### PR TITLE
Add donor advised fund (DAF) page 

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -766,6 +766,16 @@ def submit_blast():
         return render_template("error.html", message=message, bundles=bundles)
 
 
+@app.route("/donor-advised-funds")
+def daf():
+    bundles = get_bundles("donate")
+    template = "daf.html"
+
+    return render_template(
+        template,
+        bundles=bundles,
+    )
+
 @app.route("/error")
 def error():
     bundles = get_bundles("old")

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -175,11 +175,7 @@
     </div>
 
     <p class="subtext">
-       By donating, you will receive member communications at the email address you provide.
-    </p>
-
-    <p class="subtext">
-      This site is protected by reCAPTCHA and the Google
+      By donating, you will receive member communications at the email address you provide. This site is protected by reCAPTCHA and the Google
       <a href="https://policies.google.com/privacy">Privacy Policy</a> and
       <a href="https://policies.google.com/terms">Terms of Service</a> apply.
     </p>

--- a/server/static/sass/donate.scss
+++ b/server/static/sass/donate.scss
@@ -37,3 +37,12 @@ h2 {
 .gap-s {
   gap: $size-s;
 }
+
+.give-options {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  line-height: 1;
+}

--- a/server/templates/daf.html
+++ b/server/templates/daf.html
@@ -58,7 +58,7 @@
             <hr>
             <div class="has-padding">
             <div class="c-daf-button t-align-center has-b-btm-marg l-pos-rel">
-              <script>var _msdaf_id = 'a5d544ab288ed';</script><script src='https://app.dafwidget.com/api/js/source.js'></script>
+              <script>var _msdaf_id = "bd75570b15514";</script><script src="https://app.dafwidget.com/public/embed.js" integrity="sha512-utP5QLPR4lm2oUlCoOYX6Fl6ilofhsTC92rfnqK934hxW50U132E880884Rl9NxuyzJsoyxWTVVrihmC3nI/yQ==" crossorigin="anonymous"></script>
             </div>
             <p class="has-text-gray-dark t-size-s">This search tool will open a third-party website, owned and operated by an independent party. We assume no responsibility for the material.</p>
             </div>

--- a/server/templates/daf.html
+++ b/server/templates/daf.html
@@ -1,0 +1,70 @@
+{% extends "new_layout.html" %}
+
+{% block og_meta %}
+  <meta property="og:url" content="https://support.texastribune.org/donate">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
+  <meta property="og:title" content="Support Us with Donor-Advised Funds | The Texas Tribune">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
+  <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
+{% block content %}
+
+  <section class="splash splash--tall grid_separator--l">
+    <div class="grid_container grid_padded--xl">
+      <div class="grid_row grid_wrap--l">
+        <div class="col_12">
+          <h1 class="splash__headline">
+            Texans need truth. <span class="has-text-yellow">Help us report it.</span>
+          </h1>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <main class="main">
+    <section class="grid_container grid_padded--xl grid_separator--xl">
+      <div class="grid_row grid_wrap--l gap-s">
+        <div class="col_7">
+          <div id="join-today" class="donation_form grid_separator--l">
+            <p class="has-b-btm-marg t-links-underlined t-size-s"><a href="/donate" class="has-text-gray-dark">Back to donate page</a></p>
+
+            <h2 class="grid_separator has-text-gray-dark">Donor-Advised Funds</h2>
+            <p>Recommend grants to The Texas Tribune through your donor-advised fund and help us to continue to bring trusted journalism to Texas and beyond.</p>
+
+            <div class="grid_separator"></div>
+            <style>
+              .c-daf-button {
+                text-align: center;
+                padding: 20px;
+                border-radius: 5px;
+                position: relative;
+              }
+              a.daf-button-link {
+                color: #fff;
+                text-decoration: none;
+                margin: 0;
+                background-color: #348094;
+                padding: 10px 20px;
+                border-radius: 10px;
+              }
+              a.daf-button-link:hover,
+              a.daf-button-link:active {
+                background-color: #2a6e7b;
+                color: #fff;
+              }
+            </style>
+            <div class="has-padding c-daf-button">
+              <script>var _msdaf_id = 'a5d544ab288ed';</script><script src='https://app.dafwidget.com/api/js/source.js'></script>
+            </div>
+            <p class="has-text-gray-dark t-size-s">This search tool will open a third-party website, owned and operated by an independent party. We assume no responsibility for the material.</p>
+          </div>
+        </div>
+        <div class="col_5">
+          {% include 'includes/faq.html' %}
+        </div>
+      </div>
+    </section>
+  </main>
+{% endblock %}

--- a/server/templates/daf.html
+++ b/server/templates/daf.html
@@ -31,17 +31,17 @@
             <p class="has-b-btm-marg t-links-underlined t-size-s"><a href="/donate" class="has-text-gray-dark">Back to donate page</a></p>
 
             <h2 class="grid_separator has-text-gray-dark">Donor-Advised Funds</h2>
-            <p>Recommend grants to The Texas Tribune through your donor-advised fund and help us to continue to bring trusted journalism to Texas and beyond.</p>
+            <p class="has-text-gray-dark has-l-btm-marg">Recommend grants to The Texas Tribune through your donor-advised fund and help us to continue to bring trusted journalism to Texas and beyond.</p>
+
 
             <div class="grid_separator"></div>
             <style>
-              .c-daf-button {
-                text-align: center;
-                padding: 20px;
-                border-radius: 5px;
-                position: relative;
+              hr {
+                border: 0;
+                border-top: 1px solid #e5e5e5;
               }
               a.daf-button-link {
+                border-radius: 5px;
                 color: #fff;
                 text-decoration: none;
                 margin: 0;
@@ -55,10 +55,15 @@
                 color: #fff;
               }
             </style>
-            <div class="has-padding c-daf-button">
+            <hr>
+            <div class="has-padding">
+            <div class="c-daf-button t-align-center has-b-btm-marg l-pos-rel">
               <script>var _msdaf_id = 'a5d544ab288ed';</script><script src='https://app.dafwidget.com/api/js/source.js'></script>
             </div>
             <p class="has-text-gray-dark t-size-s">This search tool will open a third-party website, owned and operated by an independent party. We assume no responsibility for the material.</p>
+            </div>
+            <hr class="has-l-btm-marg">
+            <p class="has-text-gray-dark t-links-underlined">For assistance, or if your DAF is not found via the search tool, please contact James Canup, Senior Major Gift Officer, <a class="has-text-gray-dark" href="mailto:james.canup@texastribune.org?subject=Donor-Advised+Funds">james.canup@texastribune.org</a>.</p>
           </div>
         </div>
         <div class="col_5">

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -48,7 +48,13 @@
             <!-- where the form attaches -->
             <div id="top-form"></div>
             <div class="grid_separator"></div>
-            <p class="t-size-xs has-text-gray-dark"><strong>You can also give via <a href='https://www.paypal.me/texastribune'><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_100x26.png" alt="PayPal" width="70" height="18" class="l-display-ib" style="vertical-align: middle; margin-left: 3px;"></strong></a></p>
+            <div class="give-options">
+              <p class="has-text-gray-dark t-size-s">Looking for others ways to give?</p>
+              <ul class="give-options">
+                <li><a href='https://www.paypal.me/texastribune'><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_100x26.png" alt="PayPal" width="70" height="18" class="l-display-ib" style="vertical-align: middle;"></a></li>
+                <li><a class="has-text-teal t-size-s" href="/donor-advised-funds"><strong>Donor Advised Funds</strong></a></li>
+              </ul>
+            </div>
           </div>
         </div>
         <div class="col_5">


### PR DESCRIPTION
#### What's this PR do?

- Adds a new page at /donor-advised-funds
- Reworks the bottom of the form to include a link

#### Why are we doing this? How does it help us?

Request from the development team. This is apparently a popular way to give and we already have donors doing this. This widget simplifies the process for them.

#### How should this be manually tested?

- Go to the new page `/donor-advised-funds`
- Click the button and confirm a modal pops up
- Begin typing something like "Fidelity" and see that you are dropped into Fidelity's login

Note: I think that's all these DAF wigets are; they're like quick links to a directory of funds

#### How should this change be communicated to end users?

The development team is aware and has approved this. Note that this is also heavily documented in our wiki (search DAF)

#### Are there any smells or added technical debt to note?

I was a little hesitant about have a third party script in this app. See security concerns in the wiki entry for more info there.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwb2L2CHc4ZWqkC5/recklwpA4pEw57y7r?blocks=hide
#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [x] Checked for security implications? *( )*
* [x] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
