### PR TITLE
Updates for salesforce migration

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1740,7 +1740,7 @@ def close_rdo(subscription_id, method=None, contact=None, reason=None):
     #next we'll update the rdo to reflect the cancellation
     today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
     rdo_update_details = {
-        "npsp__RecurringType__c": "Closed",
+        "npsp__Status__c": "Closed",
         "Cancellation_Date__c": today,
         "Cancellation_Method__c": method,
     }

--- a/server/app.py
+++ b/server/app.py
@@ -1603,10 +1603,8 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
 
     if type == "circle":
         rdo.installments = 36 if sub_plan["interval"] == "month" else 3
-        rdo.amount = amount
-    else:
-        rdo.amount = amount
-
+    
+    rdo.amount = amount
     rdo.type = donation_type_info.get("type", None)
     rdo.stripe_customer = customer_id
     rdo.stripe_subscription = subscription["id"]

--- a/server/app.py
+++ b/server/app.py
@@ -70,22 +70,22 @@ DONATION_TYPE_INFO = {
     "membership": {
         "type": "Recurring Donation",
         "description": "Texas Tribune Sustaining Membership",
-        "open_ended_status": "Open",
+        "recurring_type": "Open",
     },
     "business_membership": {
         "type": "Business Membership",
         "description": "Texas Tribune Business Membership",
-        "open_ended_status": "Open",
+        "recurring_type": "Open",
     },
     "circle": {
         "type": "Giving Circle",
         "description": "Texas Tribune Circle Membership",
-        "open_ended_status": "None",
+        "recurring_type": "Fixed",
     },
     "blast": {
         "type": "The Blast",
         "description": "Blast Subscription",
-        "open_ended_status": "Open",
+        "recurring_type": "Open",
     },
 }
 
@@ -1267,7 +1267,7 @@ def add_circle_membership(contact=None, form=None, customer=None, quarantine=Fal
         rdo.installments = 3
 
     rdo.installment_period = installment_period
-    rdo.open_ended_status = "None"
+    rdo.recurring_type = "Fixed"
     rdo.quarantined = quarantine
 
     apply_card_details(rdo=rdo, customer=customer)
@@ -1296,7 +1296,7 @@ def add_recurring_donation(contact=None, form=None, customer=None, quarantine=Fa
     rdo.amount = form.get("amount", 0)
     rdo.installments = None
     rdo.installment_period = form["installment_period"]
-    rdo.open_ended_status = "Open"
+    rdo.recurring_type = "Open"
     rdo.quarantined = quarantine
 
     apply_card_details(rdo=rdo, customer=customer)
@@ -1337,7 +1337,7 @@ def add_blast_subscription(form=None, customer=None):
     # Blast specific:
     rdo.installments = 0
     rdo.description = "Blast Subscription"
-    rdo.open_ended_status = "Open"
+    rdo.recurring_type = "Open"
     if int(float(rdo.amount)) == 40:
         rdo.installment_period = "monthly"
     else:
@@ -1577,7 +1577,7 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
     rdo.lead_source = "Stripe"
     rdo.amount = sub_meta.get("donor_selected_amount", sub_plan["metadata"].get("donor_amount", 0))
     rdo.installment_period = installment_period
-    rdo.open_ended_status = donation_type_info.get("open_ended_status", None)
+    rdo.recurring_type = donation_type_info.get("recurring_type", None)
     rdo.quarantined = True if sub_meta.get("quarantine", None) else False
 
     #these nested gets hit three separate fields in order to try and get a card to lookup
@@ -1702,7 +1702,7 @@ def close_rdo(subscription_id, method=None, contact=None, reason=None):
     #next we'll update the rdo to reflect the cancellation
     today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
     rdo_update_details = {
-        "npe03__Open_Ended_Status__c": "Closed",
+        "npsp__RecurringType__c": "Closed",
         "Cancellation_Date__c": today,
         "Cancellation_Method__c": method,
     }

--- a/server/app.py
+++ b/server/app.py
@@ -1565,7 +1565,7 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
 
     if type == "circle":
         rdo.installments = 36 if sub_plan["interval"] == "month" else 3
-        rdo.amount = amount * rdo.installments
+        rdo.amount = amount
     else:
         rdo.amount = amount
 

--- a/server/app.py
+++ b/server/app.py
@@ -1582,9 +1582,6 @@ def log_rdo(type=None, contact=None, account=None, customer=None, subscription=N
     rdo.recurring_type = donation_type_info.get("recurring_type", None)
     rdo.quarantined = True if sub_meta.get("quarantine", None) else False
 
-    if not rdo.amount:
-        rdo.amount = amount
-
     #these nested gets hit three separate fields in order to try and get a card to lookup
     source = subscription.get(
         "default_source", subscription.get(

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -605,13 +605,15 @@ class RDO(SalesforceObject, CampaignMixin):
             raise SalesforceException("Account and Contact can't both be specified")
 
         if not date:
-            date = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
+            date = datetime.now(tz=ZONE)
         else:
-            date = datetime.fromtimestamp(date).strftime('%Y-%m-%d')
+            date = datetime.fromtimestamp(date)
+        
+        date_formatted = date.strftime("%Y-%m-%d")
 
         if contact is not None:
             self.contact_id = contact.id
-            self.name = f"{date} for {contact.first_name} {contact.last_name} ({contact.email})"
+            self.name = f"{date_formatted} for {contact.first_name} {contact.last_name} ({contact.email})"
             self.account_id = None
         elif account is not None:
             self.account_id = account.id
@@ -631,7 +633,8 @@ class RDO(SalesforceObject, CampaignMixin):
         self.referral_id = None
         self._amount = 0
         self.type = "Recurring Donation"
-        self.date_established = date
+        self.date_established = date_formatted
+        self.day_of_month = date.day
         self.stripe_customer = None
         self.stripe_subscription = None
         self.lead_source = None
@@ -666,6 +669,7 @@ class RDO(SalesforceObject, CampaignMixin):
             "npe03__Contact__c": self.contact_id,
             "npe03__Amount__c": amount,
             "npe03__Date_Established__c": self.date_established,
+            "npsp__Day_of_Month__c": self.day_of_month,
             "Name": self.name,
             "Stripe_Customer_ID__c": self.stripe_customer,
             "Stripe_Subscription_Id__c": self.stripe_subscription,

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -659,8 +659,8 @@ class RDO(SalesforceObject, CampaignMixin):
         amount = self.amount
 
         # TODO should this be in the client?
-        if self.installments:
-            amount = str(float(self.amount) * int(self.installments))
+        # if self.installments:
+        #     amount = str(float(self.amount) * int(self.installments))
 
         recurring_donation = {
             "npe03__Organization__c": self.account_id,

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -658,7 +658,7 @@ class RDO(SalesforceObject, CampaignMixin):
         # TODO be sure to reverse this on deserialization
         amount = self.amount
 
-        # TODO should this be in the client?
+        # TODO this is deprecated for the salesforce migration and can be removed after a success
         # if self.installments:
         #     amount = str(float(self.amount) * int(self.installments))
 

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -626,7 +626,7 @@ class RDO(SalesforceObject, CampaignMixin):
 
         self.id = id
         self.installments = None
-        self.open_ended_status = None
+        self.recurring_type = None
         self.installment_period = None
         self.campaign_id = None
         self.campaign_name = None
@@ -677,7 +677,7 @@ class RDO(SalesforceObject, CampaignMixin):
             "Stripe_Description__c": self.description,
             "Stripe_Agreed_to_pay_fees__c": self.agreed_to_pay_fees,
             "Encouraged_to_contribute_by__c": self.encouraged_by,
-            "npe03__Open_Ended_Status__c": self.open_ended_status,
+            "npsp__RecurringType__c": self.recurring_type,
             "npe03__Installments__c": self.installments,
             "npe03__Installment_Period__c": self.installment_period,
             "Blast_Subscription_Email__c": self.blast_subscription_email,
@@ -704,7 +704,7 @@ class RDO(SalesforceObject, CampaignMixin):
                 SELECT Id, npe03__Organization__c, Referral_ID__c, npe03__Recurring_Donation_Campaign__c,
                 npe03__Contact__c, npe03__Amount__c, npe03__Date_Established__c, Name, Stripe_Customer_Id__c,
                 Stripe_Subscription_Id__c, Lead_Source__c, Stripe_Description__c, Stripe_Agreed_to_pay_fees__c,
-                Encouraged_to_contribute_by__c, npe03__Open_Ended_Status__c, npe03__Installments__c,
+                Encouraged_to_contribute_by__c, npsp__RecurringType__c, npe03__Installments__c,
                 npe03__Installment_Period__c, Blast_Subscription_Email__c, Billing_Email__c, Type__c,
                 Stripe_Card_Brand__c, Stripe_Card_Expiration__c, Stripe_Card_Last_4__c, Quarantined__c
                 FROM npe03__Recurring_Donation__c
@@ -729,7 +729,7 @@ class RDO(SalesforceObject, CampaignMixin):
             rdo.description = response["Stripe_Description__c"]
             rdo.agreed_to_pay_fees = response["Stripe_Agreed_to_pay_fees__c"]
             rdo.encouraged_by = response["Encouraged_to_contribute_by__c"]
-            rdo.open_ended_status = response["npe03__Open_Ended_Status__c"]
+            rdo.recurring_type = response["npsp__RecurringType__c"]
             rdo.installments = response["npe03__Installments__c"]
             rdo.installment_period = response["npe03__Installment_Period__c"]
             rdo.blast_subscription_email = response["Blast_Subscription_Email__c"]
@@ -865,7 +865,7 @@ class RDO(SalesforceObject, CampaignMixin):
         # SF side
         if self.record_type_name == DEFAULT_RDO_TYPE or self.record_type_name is None:
             return
-        if self.open_ended_status == "Open":
+        if self.recurring_type == "Open":
             logging.warning(
                 f"RDO {self} is open-ended so new opportunities won't have type {self.record_type_name}"
             )

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -704,7 +704,7 @@ class RDO(SalesforceObject, CampaignMixin):
                 SELECT Id, npe03__Organization__c, Referral_ID__c, npe03__Recurring_Donation_Campaign__c,
                 npe03__Contact__c, npe03__Amount__c, npe03__Date_Established__c, Name, Stripe_Customer_Id__c,
                 Stripe_Subscription_Id__c, Lead_Source__c, Stripe_Description__c, Stripe_Agreed_to_pay_fees__c,
-                Encouraged_to_contribute_by__c, npsp__RecurringType__c, npe03__Installments__c,
+                Encouraged_to_contribute_by__c, npsp__RecurringType__c, npe03__Installments__c, npsp__Day_of_Month__c,
                 npe03__Installment_Period__c, Blast_Subscription_Email__c, Billing_Email__c, Type__c,
                 Stripe_Card_Brand__c, Stripe_Card_Expiration__c, Stripe_Card_Last_4__c, Quarantined__c
                 FROM npe03__Recurring_Donation__c
@@ -722,6 +722,7 @@ class RDO(SalesforceObject, CampaignMixin):
             rdo.contact_id = response["npe03__Contact__c"]
             rdo.amount = response["npe03__Amount__c"]
             rdo.date_established = response["npe03__Date_Established__c"]
+            rdo.day_of_month = response["npsp__Day_of_Month__c"]
             rdo.name = response["Name"]
             rdo.stripe_customer = response["Stripe_Customer_Id__c"]
             rdo.stripe_subscription = response["Stripe_Subscription_Id__c"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -454,7 +454,7 @@ def test__format_circle_donation():
         "Billing_Email__c": None,
         "Blast_Subscription_Email__c": None,
         "npe03__Organization__c": None,
-        "npe03__Amount__c": "300.0",  # 3 * 100
+        "npe03__Amount__c": "100.0",
         "Name": "foo",
         "npe03__Installments__c": 3,
         "npsp__RecurringType__c": "Fixed",
@@ -499,7 +499,7 @@ def test__format_cent_circle_donation():
         "npe03__Installment_Period__c": "yearly",
         "Stripe_Customer_ID__c": "cus_78MqJSBejMN9gn",
         "Stripe_Subscription_Id__c": None,
-        "npe03__Amount__c": "4503.03",  # 3 * 1501.01
+        "npe03__Amount__c": "1501.01",
         "Name": "foo",
         "npe03__Installments__c": 3,
         "npsp__RecurringType__c": "Fixed",
@@ -530,7 +530,7 @@ def test__format_recurring_donation():
     rdo.amount = 9
     rdo.name = "foo"
     rdo.installments = 0
-    rdo.recurring_type = None
+    rdo.recurring_type = "Open"
     rdo.description = "Texas Tribune Membership"
     rdo.agreed_to_pay_fees = True
 
@@ -578,7 +578,7 @@ def test__format_recurring_donation_decimal():
     rdo.amount = 9.15
     rdo.name = "foo"
     rdo.installments = 0
-    rdo.recurring_type = None
+    rdo.recurring_type = "Open"
     rdo.description = "Texas Tribune Membership"
     rdo.agreed_to_pay_fees = True
     rdo.quarantined = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -254,7 +254,8 @@ def test_check_response():
 
 zone = timezone("US/Central")
 
-today = datetime.now(tz=zone).strftime("%Y-%m-%d")
+today = datetime.now(tz=zone)
+today_formatted = datetime.now(tz=zone).strftime("%Y-%m-%d")
 
 
 def test__campaign_id_validation():
@@ -396,7 +397,7 @@ def test__format_opportunity():
         "AccountId": "0011700000BpR8PAAV",
         "CampaignId": None,
         "Amount": "9.00",
-        "CloseDate": today,
+        "CloseDate": today_formatted,
         "Encouraged_to_contribute_by__c": "Because I love the Trib!",
         "LeadSource": "Stripe",
         "Name": "D C (dcraigmile+test6@texastribune.org)",
@@ -433,7 +434,7 @@ def test__format_circle_donation():
     rdo.amount = 100
     rdo.name = "foo"
     rdo.installments = 3
-    rdo.open_ended_status = None
+    rdo.recurring_type = "Fixed"
     rdo.description = "Texas Tribune Circle Membership"
     rdo.agreed_to_pay_fees = True
     rdo.type = "Giving Circle"
@@ -443,7 +444,8 @@ def test__format_circle_donation():
     expected_response = {
         "Referral_ID__c": "1234",
         "Encouraged_to_contribute_by__c": "Because I love the Trib!",
-        "npe03__Date_Established__c": today,
+        "npe03__Date_Established__c": today_formatted,
+        "npsp__Day_of_Month__c": today.day,
         "Lead_Source__c": "Stripe",
         "npe03__Contact__c": "0031700000BHQzBAAX",
         "npe03__Installment_Period__c": "yearly",
@@ -455,7 +457,7 @@ def test__format_circle_donation():
         "npe03__Amount__c": "300.0",  # 3 * 100
         "Name": "foo",
         "npe03__Installments__c": 3,
-        "npe03__Open_Ended_Status__c": None,
+        "npsp__RecurringType__c": "Fixed",
         "Stripe_Description__c": "Texas Tribune Circle Membership",
         "Stripe_Agreed_to_pay_fees__c": True,
         "Type__c": "Giving Circle",
@@ -480,7 +482,7 @@ def test__format_cent_circle_donation():
     rdo.amount = 1501.01
     rdo.name = "foo"
     rdo.installments = 3
-    rdo.open_ended_status = None
+    rdo.recurring_type = "Fixed"
     rdo.description = "Texas Tribune Circle Membership"
     rdo.agreed_to_pay_fees = True
     rdo.type = "Giving Circle"
@@ -489,7 +491,8 @@ def test__format_cent_circle_donation():
     expected_response = {
         "Referral_ID__c": "1234",
         "Encouraged_to_contribute_by__c": "Because I love the Trib!",
-        "npe03__Date_Established__c": today,
+        "npe03__Date_Established__c": today_formatted,
+        "npsp__Day_of_Month__c": today.day,
         "Lead_Source__c": "Stripe",
         "npe03__Organization__c": None,
         "npe03__Contact__c": "0031700000BHQzBAAX",
@@ -499,7 +502,7 @@ def test__format_cent_circle_donation():
         "npe03__Amount__c": "4503.03",  # 3 * 1501.01
         "Name": "foo",
         "npe03__Installments__c": 3,
-        "npe03__Open_Ended_Status__c": None,
+        "npsp__RecurringType__c": "Fixed",
         "Stripe_Description__c": "Texas Tribune Circle Membership",
         "Stripe_Agreed_to_pay_fees__c": True,
         "Type__c": "Giving Circle",
@@ -527,7 +530,7 @@ def test__format_recurring_donation():
     rdo.amount = 9
     rdo.name = "foo"
     rdo.installments = 0
-    rdo.open_ended_status = None
+    rdo.recurring_type = None
     rdo.description = "Texas Tribune Membership"
     rdo.agreed_to_pay_fees = True
 
@@ -537,7 +540,8 @@ def test__format_recurring_donation():
         "Referral_ID__c": "1234",
         "npe03__Organization__c": None,
         "Encouraged_to_contribute_by__c": "Because I love the Trib!",
-        "npe03__Date_Established__c": today,
+        "npe03__Date_Established__c": today_formatted,
+        "npsp__Day_of_Month__c": today.day,
         "Lead_Source__c": "Stripe",
         "npe03__Contact__c": "0031700000BHQzBAAX",
         "npe03__Installment_Period__c": "monthly",
@@ -546,7 +550,7 @@ def test__format_recurring_donation():
         "npe03__Amount__c": "9.00",
         "Name": "foo",
         "npe03__Installments__c": 0,
-        "npe03__Open_Ended_Status__c": None,
+        "npsp__RecurringType__c": "Open",
         "Stripe_Description__c": "Texas Tribune Membership",
         "Stripe_Agreed_to_pay_fees__c": True,
         "Type__c": "Recurring Donation",
@@ -574,7 +578,7 @@ def test__format_recurring_donation_decimal():
     rdo.amount = 9.15
     rdo.name = "foo"
     rdo.installments = 0
-    rdo.open_ended_status = None
+    rdo.recurring_type = None
     rdo.description = "Texas Tribune Membership"
     rdo.agreed_to_pay_fees = True
     rdo.quarantined = True
@@ -586,7 +590,8 @@ def test__format_recurring_donation_decimal():
         "npe03__Organization__c": None,
         "Billing_Email__c": None,
         "Encouraged_to_contribute_by__c": "Because I love the Trib!",
-        "npe03__Date_Established__c": today,
+        "npe03__Date_Established__c": today_formatted,
+        "npsp__Day_of_Month__c": today.day,
         "Lead_Source__c": "Stripe",
         "Blast_Subscription_Email__c": None,
         "npe03__Contact__c": "0031700000BHQzBAAX",
@@ -596,7 +601,7 @@ def test__format_recurring_donation_decimal():
         "npe03__Amount__c": "9.15",
         "Name": "foo",
         "npe03__Installments__c": 0,
-        "npe03__Open_Ended_Status__c": None,
+        "npsp__RecurringType__c": "Open",
         "Stripe_Description__c": "Texas Tribune Membership",
         "Stripe_Agreed_to_pay_fees__c": True,
         "Type__c": "Recurring Donation",
@@ -621,7 +626,7 @@ def test__format_blast_rdo():
     rdo.amount = 40
     rdo.name = "foo"
     rdo.installments = 0
-    rdo.open_ended_status = "Open"
+    rdo.recurring_type = "Open"
     rdo.description = "Monthly Blast Subscription"
     rdo.agreed_to_pay_fees = True
     rdo.type = "The Blast"
@@ -634,7 +639,8 @@ def test__format_blast_rdo():
     expected_response = {
         "Referral_ID__c": "1234",
         "Encouraged_to_contribute_by__c": None,
-        "npe03__Date_Established__c": today,
+        "npe03__Date_Established__c": today_formatted,
+        "npsp__Day_of_Month__c": today.day,
         "Lead_Source__c": "Stripe",
         "npe03__Contact__c": "0031700000BHQzBAAX",
         "npe03__Installment_Period__c": "monthly",
@@ -643,7 +649,7 @@ def test__format_blast_rdo():
         "npe03__Amount__c": "40.00",
         "Name": "foo",
         "npe03__Installments__c": 0,
-        "npe03__Open_Ended_Status__c": "Open",
+        "npsp__RecurringType__c": "Open",
         "Stripe_Description__c": "Monthly Blast Subscription",
         "Stripe_Agreed_to_pay_fees__c": True,
         "Type__c": "The Blast",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -454,7 +454,7 @@ def test__format_circle_donation():
         "Billing_Email__c": None,
         "Blast_Subscription_Email__c": None,
         "npe03__Organization__c": None,
-        "npe03__Amount__c": "100.0",
+        "npe03__Amount__c": "100.00",
         "Name": "foo",
         "npe03__Installments__c": 3,
         "npsp__RecurringType__c": "Fixed",


### PR DESCRIPTION
#### What's this PR do?
Updates a handful of things to get donations working with Salesforce post-migration.

#### Why are we doing this? How does it help us?
The migration itself helps clean-up our Salesforce infrastructure and these updates are reqs to keep the donations pages working in tandem with the new Salesforce updates.

#### How should this be manually tested?
* In general, this is easiest to test on staging
* Attempt giving these donations and check that they showed up correctly in Salesforce (stripe should be unaffected)
    * sustaining (/donate)
    * circle
    * business
    * blast
    * Waco should be the same as sustaining, but you can test this if you feel the need
* Get into the portal and check these things
    * the membership sections looks correct (should show all memberships, the amount and some card info
    * a subscription's card info can be updated
    * a subscription can be cancelled
    * the info in the donation history section looks right

#### How should this change be communicated to end users?
This we'll be announced to the membership team alongside the successful migration of Salesforce after the weekend.

#### Are there any smells or added technical debt to note?
There is probably some more clean-up that can be done here around the way opportunities are called that might make things faster, but the initial plan here was just getting everything working with the new migration.

#### What are the relevant tickets?
This overall Airtable project contains any specific tasks ->
https://airtable.com/appyo1zuQd8f4hBVx/tbl91AYzukCviHliZ/viwM0ORfIqHNiIkaf/recKTDL19XkrAZ1q2?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:
* a separate one-off pr will be created to purposefully error out calls to our stripe hook endpoint and deployed
* Anna will run the SF migration (this step will likely take a couple of hours)
* If all looks good we'll deploy this pr
* another separate one-off pr that turns off the purposeful erroring out functionality will be deployed
* I'll manually re-send all the stripe events that errored out and make sure they sync as expected