### PR TITLE
Temp stripehook block

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1175,6 +1175,8 @@ def stripehook():
 
     app.logger.info(f"Received event: id={event.id}, type={event.type}")
 
+    return "Temporarily blocked", 400
+
     process_stripe_event(event)
 
     return "Success", 200

--- a/server/app.py
+++ b/server/app.py
@@ -597,11 +597,9 @@ if ENABLE_PORTAL:
     @app.route("/account/", defaults={"path": ""})
     @app.route("/account/<path>/")
     def account(path):
+        message = "The membership dashboard is temporarily unavailable during site maintenance. Expect the dashboard to be available again by Sunday, July 28th. Any further downtime will be announced here."
         return render_template(
-            "account.html",
-            bundles=get_bundles("account"),
-            stripe=app.config["STRIPE_KEYS"]["publishable_key"],
-            recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
+            "error.html", message=message, bundles=get_bundles("old")
         )
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -420,11 +420,13 @@ def add_stripe_donation(form=None, customer=None, donation_type=None, bad_actor_
     period = form["installment_period"]
 
     if quarantine:
-        contact = get_or_create_contact(form)
+        # contact = get_or_create_contact(form)
+        app.logger.warning(f"New contact will need to be created for {customer['id']}")
+        app.logger.info(f"Form for {customer['id']}: {form}")
         form["source"] = customer["id"]
         form["amount_w_fees"] = float(amount_to_charge(form))
         bad_actor_response.notify_bad_actor(
-            transaction=contact,
+            transaction=customer,
             transaction_data=form
         )
         return True

--- a/server/bad_actor.py
+++ b/server/bad_actor.py
@@ -84,7 +84,7 @@ class BadActor:
     def _slackify_all(self) -> list:
 
         # add another item for the Salesforce link
-        txn_url = f"https://dashboard.stripe.com/customers/{self.transaction["id"]}"
+        txn_url = f"https://dashboard.stripe.com/customers/{self.transaction['id']}"
         slackified_txn_link = f"<{txn_url}|Stripe>"
         sf_link_item = BadActorResponseItem(
             label="",

--- a/server/bad_actor.py
+++ b/server/bad_actor.py
@@ -84,8 +84,8 @@ class BadActor:
     def _slackify_all(self) -> list:
 
         # add another item for the Salesforce link
-        txn_url = f"{self.transaction.sf.instance_url}/{self.transaction.id}"
-        slackified_txn_link = f"<{txn_url}|Salesforce>"
+        txn_url = f"https://dashboard.stripe.com/customers/{self.transaction["id"]}"
+        slackified_txn_link = f"<{txn_url}|Stripe>"
         sf_link_item = BadActorResponseItem(
             label="",
             value=slackified_txn_link,


### PR DESCRIPTION
#### What's this PR do?
* turns off calls to salesforce in the donation process
* logs form info for future processing where appropriate (Contact creation in SF, for instance)
* returns error page with message about downtime for calls to /account

#### Why are we doing this? How does it help us?
These are all measures to block access to Salesforce during the downtime of the salesforce migration

#### How should this be manually tested?
deployed this pr to staging
checked /account returned and error page with message
ensured donations still made it through to stripe (staging)
deployed the post-sf migration pr to staging
ensured blocked stripe (staging) events from ^ could be rerun

#### How should this change be communicated to end users?
I can announce it.

#### Are there any smells or added technical debt to note?
I'll create a revert pr right after this is deployed

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
