### PR TITLE
less strict syncing

### DIFF
--- a/app.json
+++ b/app.json
@@ -105,6 +105,9 @@
     "MAILTRAP_API_TOKEN": {
       "required": true
     },
+    "MAX_SYNC_DAYS_DIFFERENCE": {
+      "required": false
+    },
     "MULTIPLE_ACCOUNT_WARNING_MAIL_RECIPIENT": {
       "required": true
     },

--- a/server/config.py
+++ b/server/config.py
@@ -11,6 +11,7 @@ def bool_env(val):
 
 
 TIMEZONE = os.getenv("TIMEZONE", "US/Central")
+MAX_SYNC_DAYS_DIFFERENCE = os.getenv("MAX_SYNC_DAYS_DIFFERENCE", 10)
 
 #######
 # Flask


### PR DESCRIPTION
#### What's this PR do?
* makes it so we can get around a strict exception if needed
* also makes it so the MAX_SYNC_DAYS_DIFFERENCE var can be controlled from heroku (probably should have always been this way)

#### Why are we doing this? How does it help us?
The exception in question is good to know about, but once we figure out what's going on, we want to be able to rerun a donation through the salesforce sync and expect that the sync gets around the exception.

#### How should this be manually tested?
Sadly, this is another one of those edge cases that would be overly difficult to replicate in a testing scenario. Suffice it to say, this update won't effect the regular donation/sync flow and I'll rerun the donation in question after this is in place to make sure it works as expected.

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
Naw.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recmm6dVQibvmzmO1?blocks=hide
