### PR TITLE
fix metadata amount bug

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1068,7 +1068,7 @@ def setup_intent_succeeded(setup_intent_id):
             },
             items = [{
                 "price_data": {
-                    "unit_amount": int(metadata["amount"] * 100),
+                    "unit_amount": int(float(metadata["amount"]) * 100),
                     "currency": "usd",
                     "product": STRIPE_PRODUCTS["membership"],
                     "recurring": {"interval": metadata["interval"]},
@@ -1232,6 +1232,7 @@ def process_stripe_event(event):
     if event_type == "subscription_schedule.updated":
         subscription_schedule_updated.delay(event)
     if event_type == "setup_intent.succeeded":
+        app.logger.info(f"setup intent succeeded event: {event}")
         setup_intent_succeeded.delay(event_object["id"])
 
     return True


### PR DESCRIPTION
#### What's this PR do?
since the amount comes over as a string in the metadata, we need to use float to get it back to the original format before multiplying it for stripe's expected format... makes sense, right?

#### Why are we doing this? How does it help us?
recurring donations created at the card reader are currently not making it all the way through the process (luckily with this fix, we can easily rerun any failed subs that ran through the day (of which there is currently only 1))

#### How should this be manually tested?
I'll rerun the failed sub after this deploys.

#### How should this change be communicated to end users?
I'll let the Emily know since she caught the failure earlier.

#### Are there any smells or added technical debt to note?
No.
