### PR TITLE
switch waco base to /donate

### DIFF
--- a/server/static/js/src/entry/waco/TopForm.vue
+++ b/server/static/js/src/entry/waco/TopForm.vue
@@ -1,7 +1,7 @@
 <template>
   <form
     ref="form"
-    action="/waco"
+    action="/donate"
     method="post"
     class="form"
     @submit="$event.preventDefault()"

--- a/server/static/js/src/entry/waco/router.js
+++ b/server/static/js/src/entry/waco/router.js
@@ -71,7 +71,7 @@ function createInitialFormState(queryParams) {
 
 function createRouter() {
   return new VueRouter({
-    base: '/waco',
+    base: '/donate',
     mode: 'history',
     routes: [{ path: '/', component: RouteHandler }],
   });


### PR DESCRIPTION
the base waco donation page is at /donate now, not /waco, since the waco base and tt base no longer are served in the same deploy

skipping all of the usual paperwork since this is just a bug/typo fix
