### PR TITLE
Add Waco tracking

### DIFF
--- a/server/templates/includes/tracking_nojs_waco.html
+++ b/server/templates/includes/tracking_nojs_waco.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PL78MFQB"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->

--- a/server/templates/includes/tracking_waco.html
+++ b/server/templates/includes/tracking_waco.html
@@ -1,0 +1,17 @@
+<!-- Google Tag Manager - container for Waco -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-PL78MFQB');</script>
+  <!-- End Google Tag Manager -->
+
+<!-- Google Analytics - Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3J5P5YXE2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-G3J5P5YXE2');
+</script>

--- a/server/templates/new_layout_newsroom.html
+++ b/server/templates/new_layout_newsroom.html
@@ -25,12 +25,14 @@
       <link rel="stylesheet" type="text/css" href="{{ bundles['css'] }}">
     {% endblock %}
 
-    <!-- ADD GA HERE -->
+    <!-- Page tracking -->
+    {% include 'includes/tracking_' + newsroom.name +  '.html' %}
 
     {% block adwords_conversion_code %}{% endblock %}
     {% block head_scripts %}{% endblock %}
   </head>
   <body>
+    {% include 'includes/tracking_nojs_' + newsroom.name +  '.html' %}
 
     {% block icon_sprite %}
       {# SVG sprite include #}


### PR DESCRIPTION
#### What's this PR do?

Adds the new GA property and GTM container codes to the Waco pages

#### Why are we doing this? How does it help us?

Helps us track traffic and donation events on this page

#### How should this be manually tested?

Not required but:
Go to debug view in the waco property in GA
or
confirm the page_view is coming through via GA debugger (chrome extension)
![Screenshot 2024-09-18 at 3 43 07 PM](https://github.com/user-attachments/assets/7f62a637-7c65-4e4d-a557-0e8f82035cbd)

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

There could be a world where we're just swapping out ids instead. I especially hate how I had to add two separate includes. Good thing to revisit later

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/pagfWppWvuH0LMgoo?detail=eyJwYWdlSWQiOiJwYWdYZ3RSUnVJeXpHa0pjNiIsInJvd0lkIjoicmVjb3l6bld2RTJQUkQ4akwiLCJzaG93Q29tbWVudHMiOmZhbHNlLCJxdWVyeU9yaWdpbkhpbnQiOm51bGx9

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
