### PR TITLE
fix monthly suggested donation

### DIFF
--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -243,8 +243,8 @@ export default {
     // in hopes of getting more recurring monthly donations
     // using Math.ceil() here to round up to the nearest whole int
     this.initMonthlyAmount = String(Math.ceil(this.initAmount/10));
-    if (this.initFrequency == 'monthly') {
-      this.updateValue({ storeModule: storeModule, key: 'amount', value: this.initMonthlyAmount})
+    if (this.initFrequency === 'monthly') {
+      this.updateValue({ storeModule, key: 'amount', value: this.initMonthlyAmount})
     }
   },
 
@@ -254,16 +254,16 @@ export default {
       const getter = this.$store.getters[`${storeModule}/valueByKey`];
       let amount = getter('amount');
       let needsUpdate = false;
-      if (frequency == 'monthly' && amount == initAmount) {
+      if (frequency === 'monthly' && amount === initAmount) {
         amount = initMonthlyAmount;
         needsUpdate = true;
-      } else if (frequency != 'monthly' && amount == initMonthlyAmount) {
+      } else if (frequency !== 'monthly' && amount === initMonthlyAmount) {
         amount = initAmount;
         needsUpdate = true;
       };
       // only update if the current value matches the initial amount or the initial monthly amount
       if (needsUpdate) {
-        this.updateValue({ storeModule: storeModule, key: 'amount', value: amount})
+        this.updateValue({ storeModule, key: 'amount', value: amount})
       };
     },
   }


### PR DESCRIPTION
#### What's this PR do?
Adds functionality that makes the monthly suggested donation a tenth the amount of the yearly/one-time suggested donation on page-load

#### Why are we doing this? How does it help us?
We're hoping to see improved numbers of monthly recurring donors by suggesting a more reasonable donation amount (our current suggested amount in most instances is $200 across the board)

#### How should this be manually tested?
* load locally with 'make'
* visit /donate
* ensure that switching between 'Monthly' and 'Yearly/One Time' causes the amount to change with a ratio of 1 to 10 respectively
* ensure that changing the amount breaks this behavior (i.e. you can click between 'monthly' and 'yearly' and the amount will stay the same)

#### How should this change be communicated to end users?
We'll let membership know

#### Are there any smells or added technical debt to note?
Utilizing "touched" logic (has the amount field been clicked on and changed by the user?) would allow for this to be even smoother.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recAbvCibzXZjDT6G?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
