### PR TITLE
Fix REDIS_URL in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           docker build -f Dockerfile -t texastribune/checkout:dev .
           docker run -it --rm --workdir=/app \
           -e SECRET_KEY='sk_test_circle' \
+          -e REDIS_URL='redis://redis:6379' \
           --entrypoint=/app/circle.sh \
           texastribune/checkout:dev
 branches:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,3 @@ services:
     ports:
       - 80:5000
     entrypoint: python -m pytest "tests" --cov=.
-    environment:
-      - SECRET_KEY=sk_test_ok
-      - REDIS_URL="http://redis.test.com"


### PR DESCRIPTION
#### What's this PR do?

Adds an env var `REDIS_URL` to the circle build

#### Why are we doing this? How does it help us?

We introduced a breaking commit in #1220 

#### How should this be manually tested?

N/A just let circle do its thing

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

@matthewdylan I remember that environment bit in the docker-compose.test.yml because it seemed like that wasn't doing anything. Let me know if I missed a detail there though.

#### What are the relevant tickets?

off-sprint, but wanted to get this working for upgrading the heroku stack