### PR TITLE
add boots faq line

### DIFF
--- a/server/templates/includes/faq.html
+++ b/server/templates/includes/faq.html
@@ -3,6 +3,19 @@
   <ul class="c-faq t-size-s has-xxs-btm-marg has-bg-white has-xs-padding is-rounded-b t-links-underlined">
     <li class="c-faq__item">
       <details>
+        <summary class="c-faq__summary l-pos-rel gtm-custom-qa-dropdown" data-qa-title="FAQ" data-qa-question="What is the prize associated with the Symposium on the Future of Rural Texas?">
+          <h3 class="t-size-s">What is the prize associated with the Symposium on the Future of Rural Texas?</h3>
+          <span class="c-icon c-icon--baseline t-size-xs c-faq__icon c-icon l-height-full l-pos-abs">
+            <svg aria-hidden="true">
+              <use href="#caret-down"></use>
+            </svg>
+          </span>
+        </summary>
+        <p class="t-serif has-b-btm-marg">You could win an $800 gift certificate to Petite Paloma to redeem for the boots of your choice. Full prize details available at <a href="https://texastribune.org/boots-prize">texastribune.org/boots-prize</a>.</p>
+      </details>
+    </li>
+    <li class="c-faq__item">
+      <details>
         <summary class="c-faq__summary l-pos-rel gtm-custom-qa-dropdown" data-qa-title="FAQ" data-qa-question="How do I know if I’m a Texas Tribune member?">
           <h3 class="t-size-s">How do I know if I’m a Texas Tribune member?</h3>
           <span class="c-icon c-icon--baseline t-size-xs c-faq__icon c-icon l-height-full l-pos-abs">


### PR DESCRIPTION
#### What's this PR do?
Why it informs our readers/donors about the boots prize, of course!

#### Why are we doing this? How does it help us?
We have boots. Donors want to win 'em and need to be informed of this possibility. It's a win win!

#### How should this be manually tested?
Roll on over to your local donation spin-up and visit /donate
Ensure the first entry in the FAQ module on the right tells us what we need to know about boot winnin'

#### How should this change be communicated to end users?
We'll let Emily know it's live on Monday

#### Are there any smells or added technical debt to note?
The /boots-prize url doesn't seem to be live yet so we'll just want to make sure that's good to go before Mon.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viw2eOTqOWglhM7UI/recJAKaJY3UTxzl7F?blocks=hide
