### PR TITLE
Remove a/b testing check for dynamic donation amounts

### DIFF
--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -262,12 +262,12 @@ export default {
       let needsUpdate = false;
 
       if (initAltFrequency.includes(frequency)) {
-        if (amount === initAmount && abTesting) {
+        if (amount === initAmount) {
           amount = initAltAmount;
           needsUpdate = true;
         };
       } else {
-        if (amount === initAltAmount && abTesting) {
+        if (amount === initAltAmount) {
           amount = initAmount;
           needsUpdate = true;
         };

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -258,7 +258,8 @@ export default {
       const { storeModule, initAmount, initAltAmount, initAltFrequency } = this;
       const getter = this.$store.getters[`${storeModule}/valueByKey`];
       let amount = getter('amount');
-      const abTesting = getter('proof');
+      // comment in the next line for testing purposes
+      // const abTesting = getter('proof');
       let needsUpdate = false;
 
       if (initAltFrequency.includes(frequency)) {


### PR DESCRIPTION
#### What's this PR do?
Removes the check for an a/b testing query so that these dynamics amounts show for anyone on the page.

#### Why are we doing this? How does it help us?
Makes this feature work for anyone visiting the donate page.

#### How should this be manually tested?
Visit /donate
Ensure the amount changes when switching between monthly, yearly and one-time
Ensure the amount DOES NOT change after manually changing the amount

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
Not for this in particular.
