### PR TITLE
Add new blast page

### DIFF
--- a/app.json
+++ b/app.json
@@ -204,6 +204,9 @@
     "STRIPE_WEBHOOK_SECRET": {
       "required": true
     },
+    "BLAST_LEGE_CAMPAIGN_ID": {
+      "required": false
+    },
     "WACO_CAMPAIGN_ID": {
       "required": false
     },

--- a/config/constants.js
+++ b/config/constants.js
@@ -4,7 +4,7 @@ const SVG_LOCAL_DIR = './server/static/svg';
 const SVG_LIB_DIR = './node_modules/@texastribune/queso-ui/assets/icons/base/';
 const SVG_OUTPUT_SPRITE = './server/templates/includes/base_icons.html';
 
-const SCSS_FILES = ['account', 'business', 'charge', 'circle', 'donate', 'old', 'waco'];
+const SCSS_FILES = ['account', 'blast', 'business', 'charge', 'circle', 'donate', 'old', 'waco'];
 
 const SVG_LIB_FILES = [
   'bars',

--- a/server/app.py
+++ b/server/app.py
@@ -520,7 +520,10 @@ def do_charge_or_show_errors(form_data, template, bundles, function, donation_ty
         donation_type=donation_type,
         bad_actor_request=bad_actor_request,
     )
-    charge_template = f"charge_{NEWSROOM['name']}.html" if donation_type != "waco" else "charge_waco.html"
+    if donation_type == "blast":
+        charge_template = "blast-charge.html"
+    else:
+        charge_template = f"charge_{NEWSROOM['name']}.html" if donation_type != "waco" else "charge_waco.html"
     bundles = get_bundles(NEWSROOM["name"] if NEWSROOM["name"] != "texas" else "donate")
     gtm = {
         "event_value": amount,

--- a/server/app.py
+++ b/server/app.py
@@ -245,12 +245,6 @@ support.texastribune.org.
 """
 
 
-@app.route("/blast-vip")
-# @app.route("/blast-promo")
-def the_blastvip_form():
-    return redirect("/blastform", code=302)
-
-
 @app.route("/")
 @app.route("/levels.html")
 @app.route("/faq.html")
@@ -266,6 +260,13 @@ def index_html_route():
 def circle_html_route():
     query_string = request.query_string.decode("utf-8")
     return redirect("/circle?%s" % query_string, code=302)
+
+
+@app.route("/blast-vip")
+@app.route("/blast-promo")
+@app.route("/blastform")
+def blast_html_route():
+    return redirect("/blast", code=302)
 
 
 """
@@ -686,7 +687,6 @@ def business_form():
         recaptcha=app.config["RECAPTCHA_KEYS"]["site_key"],
     )
 
-
 @app.route("/blast", methods=["GET", "POST"])
 def blast_form():
     if NEWSROOM["name"] != "texas":
@@ -726,7 +726,7 @@ def waco_form():
     )
 
 
-@app.route("/blast-promo")
+# @app.route("/blast-promo")
 def the_blast_promo_form():
     if NEWSROOM["name"] != "texas":
         return redirect(url_for("donate_form"))
@@ -779,7 +779,7 @@ def submit_blast_promo():
         return render_template("error.html", message=message, bundles=bundles, newsroom=NEWSROOM)
 
 
-@app.route("/blastform")
+# @app.route("/blastform")
 def the_blast_form():
     if NEWSROOM["name"] != "texas":
         return redirect(url_for("donate_form"))
@@ -1603,6 +1603,7 @@ def find_price(prices=[], period=None, pay_fees=False):
     nickname = "fees" if pay_fees else None
     interval = "month" if period == "monthly" else "year"
     for price in prices:
+        app.logger.info(f'id: interval -> {price["id"]}: {price["recurring"]["interval"]}')
         if price["recurring"]["interval"] == interval \
             and price["nickname"] == nickname:
             return price

--- a/server/app.py
+++ b/server/app.py
@@ -568,7 +568,10 @@ def validate_form(FormType, bundles, template, function=add_donation.delay):
         function = add_stripe_donation.delay
     elif FormType is BlastForm:
         donation_type = "blast"
-        if form_data['installment_period'] == "session":
+        if form_data['installment_period'] == "one-time":
+            # this is the special session-only option
+            # the text comes through as one-time, but these are yearly subscriptions in Stripe
+            # we will need to close manually at the end of the session
             form_data["campaign_id"] = BLAST_LEGE_CAMPAIGN_ID
         function = add_stripe_donation.delay
     elif FormType is BlastFormLegacy:

--- a/server/app.py
+++ b/server/app.py
@@ -457,10 +457,7 @@ def do_charge_or_show_errors(form_data, template, bundles, function, donation_ty
     shipping_city = form_data.get("shipping_city", None)
     shipping_street = form_data.get("shipping_street", None)
     shipping_state = form_data.get("shipping_state", None)
-    if "zipcode" in form_data:
-        zipcode = form_data["zipcode"]
-    else:
-        zipcode = form_data["shipping_postalcode"]
+    zipcode = form_data.get("zipcode", form_data.get("shipping_postalcode", None))
     website = form_data.get("website", None)
     business_name = form_data.get("business_name", None)
 
@@ -1570,7 +1567,7 @@ def create_subscription(donation_type=None, customer=None, form=None, quarantine
         "referral_id": form.get("referral_id", None),
         "pay_fees": 'X' if form["pay_fees_value"] else None,
         "encouraged_by": form.get("reason", None),
-        "subscriber_email": form.get("subscriber_email", None),
+        "subscriber_email": form.get("stripeEmail", None),
         "quarantine": 'X' if quarantine else None,
     }
 

--- a/server/config.py
+++ b/server/config.py
@@ -86,7 +86,11 @@ STRIPE_PRODUCTS = {
     "leadershipYearly": os.getenv("STRIPE_PRODUCT_LEADERSHIP", ""),
     "editorMonthly": os.getenv("STRIPE_PRODUCT_EDITOR", ""),
     "editorYearly": os.getenv("STRIPE_PRODUCT_EDITOR", ""),
-    "blast": os.getenv("STRIPE_PRODUCT_BLAST", ""),
+    "blastMonthly": os.getenv("STRIPE_PRODUCT_BLAST", ""),
+    "blastYearly": os.getenv("STRIPE_PRODUCT_BLAST", ""),
+    "blastAcademicMonthly": os.getenv("STRIPE_PRODUCT_BLAST_ACADEMIC", ""),
+    "blastAcademicYearly": os.getenv("STRIPE_PRODUCT_BLAST_ACADEMIC", ""),
+    "blastLegislativeYearly": os.getenv("STRIPE_PRODUCT_BLAST_LEGISLATIVE", ""),
     "blastTaxExempt": os.getenv("STRIPE_PRODUCT_BLAST_TAX_EXEMPT", ""),
     "waco": os.getenv("STRIPE_PRODUCT_WACO_SUSTAINING", ""),
 }

--- a/server/config.py
+++ b/server/config.py
@@ -90,7 +90,7 @@ STRIPE_PRODUCTS = {
     "blastYearly": os.getenv("STRIPE_PRODUCT_BLAST", ""),
     "blastAcademicMonthly": os.getenv("STRIPE_PRODUCT_BLAST_ACADEMIC", ""),
     "blastAcademicYearly": os.getenv("STRIPE_PRODUCT_BLAST_ACADEMIC", ""),
-    "blastLegislativeYearly": os.getenv("STRIPE_PRODUCT_BLAST_LEGISLATIVE", ""),
+    "blastLegislativeSession": os.getenv("STRIPE_PRODUCT_BLAST_LEGISLATIVE", ""),
     "blastTaxExempt": os.getenv("STRIPE_PRODUCT_BLAST_TAX_EXEMPT", ""),
     "waco": os.getenv("STRIPE_PRODUCT_WACO_SUSTAINING", ""),
 }

--- a/server/config.py
+++ b/server/config.py
@@ -94,6 +94,7 @@ STRIPE_PRODUCTS = {
     "blastTaxExempt": os.getenv("STRIPE_PRODUCT_BLAST_TAX_EXEMPT", ""),
     "waco": os.getenv("STRIPE_PRODUCT_WACO_SUSTAINING", ""),
 }
+BLAST_LEGE_CAMPAIGN_ID = os.getenv("BLAST_LEGE_CAMPAIGN_ID", "")
 
 #######
 # Slack

--- a/server/forms.py
+++ b/server/forms.py
@@ -111,7 +111,7 @@ class WacoForm(BaseForm):
 
 class BlastForm(BaseForm):
     installment_period = StringField(
-        u"Installment Period", [validators.AnyOf(["yearly", "monthly"])]
+        u"Installment Period", [validators.AnyOf(["yearly", "monthly", "session"])]
     )
     level = HiddenField(u"Level", [validators.InputRequired()])
 

--- a/server/forms.py
+++ b/server/forms.py
@@ -111,7 +111,7 @@ class WacoForm(BaseForm):
 
 class BlastForm(BaseForm):
     installment_period = StringField(
-        u"Installment Period", [validators.AnyOf(["yearly", "monthly", "session"])]
+        u"Installment Period", [validators.AnyOf(["yearly", "monthly", "one-time"])]
     )
     level = HiddenField(u"Level", [validators.InputRequired()])
 

--- a/server/forms.py
+++ b/server/forms.py
@@ -66,7 +66,6 @@ class BaseForm(FlaskForm):
     pay_fees_value = HiddenField(
         u"Pay Fees Value", [validators.AnyOf(["True", "False"])]
     )
-    reason = StringField(u"I am giving because", [validators.Length(max=255)])
     campaign_id = HiddenField("Campaign ID")
     referral_id = HiddenField("Referral ID")
 
@@ -76,6 +75,7 @@ class DonateForm(BaseForm):
         u"Installment Period", [validators.AnyOf(["yearly", "monthly", "None"])]
     )
     zipcode = StringField(u"ZIP Code", [validators.Length(max=5)])
+    reason = StringField(u"I am giving because", [validators.Length(max=255)])
 
 
 class CircleForm(BaseForm):
@@ -83,6 +83,7 @@ class CircleForm(BaseForm):
         u"Installment Period", [validators.AnyOf(["yearly", "monthly"])]
     )
     zipcode = StringField(u"ZIP Code", [validators.Length(max=5)])
+    reason = StringField(u"I am giving because", [validators.Length(max=255)])
     level = HiddenField(u"Level", [validators.InputRequired()])
 
 
@@ -96,6 +97,7 @@ class BusinessMembershipForm(BaseForm):
     shipping_street = StringField("Shipping Street", [validators.Length(max=255)])
     shipping_postalcode = StringField(u"ZIP Code", [validators.Length(max=20)])
     installment_period = StringField([validators.AnyOf(["yearly", "monthly"])])
+    reason = StringField(u"I am giving because", [validators.Length(max=255)])
     level = HiddenField(u"Level", [validators.InputRequired()])
 
 
@@ -104,9 +106,16 @@ class WacoForm(BaseForm):
         u"Installment Period", [validators.AnyOf(["yearly", "monthly", "None"])]
     )
     zipcode = StringField(u"ZIP Code", [validators.Length(max=5)])
+    reason = StringField(u"I am giving because", [validators.Length(max=255)])
 
 
-class BlastForm(FlaskForm):
+class BlastForm(BaseForm):
+    installment_period = StringField(
+        u"Installment Period", [validators.AnyOf(["yearly", "monthly"])]
+    )
+    level = HiddenField(u"Level", [validators.InputRequired()])
+
+class BlastFormLegacy(FlaskForm):
     first_name = StringField(
         u"First name", [validators.required(message="Your first name is required.")]
     )

--- a/server/static/js/src/connected-elements/FormBuckets.vue
+++ b/server/static/js/src/connected-elements/FormBuckets.vue
@@ -21,7 +21,7 @@
         name="level"
         @updateCallback="onUpdate"
       />
-      <div class="form-buckets__footer">{{ bucket.footer }}</div>
+      <div v-if="bucket.footer" class="form-buckets__footer">{{ bucket.footer }}</div>
     </div>
   </div>
 </template>

--- a/server/static/js/src/connected-elements/FormBuckets.vue
+++ b/server/static/js/src/connected-elements/FormBuckets.vue
@@ -87,7 +87,6 @@ export default {
 
       Object.keys(allLevels).forEach(levelName => {
         const level = allLevels[levelName];
-        console.log(level);
         const { bucket, bucketFull, isFeatured, isDefault, prompt, footer } = level;
 
         if (tempBuckets[bucket]) {
@@ -110,10 +109,10 @@ export default {
           id: index,
           name: bucketName,
           heading: bucketFull,
-          isFeatured: isFeatured,
-          isDefault: isDefault,
-          prompt: prompt,
-          footer: footer,
+          isFeatured,
+          isDefault,
+          prompt,
+          footer,
           options: this.buildOptions(levelNames),
         };
       });

--- a/server/static/js/src/connected-elements/FormBuckets.vue
+++ b/server/static/js/src/connected-elements/FormBuckets.vue
@@ -5,10 +5,14 @@
       :key="bucket.id"
       :class="{
         'form-buckets__item--selected': selectedBucket === bucket.name,
+        'form-buckets__item--selected_border_bottom': (bucket.isDefault || bucket.isFeatured) && selectedBucket === bucket.name,
+        'form-buckets__item--unselected': !bucket.isFeatured && selectedBucket !== bucket.name,
+        'form-buckets__item--unselected_border_bottom': bucket.isDefault && selectedBucket !== bucket.name,
         'form-buckets__item--featured': bucket.isFeatured && selectedBucket !== bucket.name,
       }"
       class="form-buckets__item col_4 grid_separator"
     >
+      <div class="form-buckets__prompt">{{ bucket.prompt }}</div>
       <p class="form-buckets__header grid_separator">{{ bucket.heading }}</p>
       <radios
         :options="bucket.options"
@@ -17,6 +21,7 @@
         name="level"
         @updateCallback="onUpdate"
       />
+      <div class="form-buckets__footer">{{ bucket.footer }}</div>
     </div>
   </div>
 </template>
@@ -82,7 +87,8 @@ export default {
 
       Object.keys(allLevels).forEach(levelName => {
         const level = allLevels[levelName];
-        const { bucket, bucketFull, isFeatured } = level;
+        console.log(level);
+        const { bucket, bucketFull, isFeatured, isDefault, prompt, footer } = level;
 
         if (tempBuckets[bucket]) {
           tempBuckets[bucket].levelNames.push(levelName);
@@ -90,18 +96,24 @@ export default {
           tempBuckets[bucket] = {
             bucketFull,
             isFeatured,
+            isDefault,
+            prompt,
+            footer,
             levelNames: [levelName],
           };
         }
       });
 
       return Object.keys(tempBuckets).map((bucketName, index) => {
-        const { bucketFull, isFeatured, levelNames } = tempBuckets[bucketName];
+        const { bucketFull, isFeatured, isDefault, prompt, footer, levelNames } = tempBuckets[bucketName];
         return {
           id: index,
           name: bucketName,
           heading: bucketFull,
           isFeatured: isFeatured,
+          isDefault: isDefault,
+          prompt: prompt,
+          footer: footer,
           options: this.buildOptions(levelNames),
         };
       });

--- a/server/static/js/src/connected-elements/FormBuckets.vue
+++ b/server/static/js/src/connected-elements/FormBuckets.vue
@@ -5,6 +5,7 @@
       :key="bucket.id"
       :class="{
         'form-buckets__item--selected': selectedBucket === bucket.name,
+        'form-buckets__item--featured': bucket.isFeatured && selectedBucket !== bucket.name,
       }"
       class="form-buckets__item col_4 grid_separator"
     >
@@ -81,24 +82,26 @@ export default {
 
       Object.keys(allLevels).forEach(levelName => {
         const level = allLevels[levelName];
-        const { bucket, bucketFull } = level;
+        const { bucket, bucketFull, isFeatured } = level;
 
         if (tempBuckets[bucket]) {
           tempBuckets[bucket].levelNames.push(levelName);
         } else {
           tempBuckets[bucket] = {
             bucketFull,
+            isFeatured,
             levelNames: [levelName],
           };
         }
       });
 
       return Object.keys(tempBuckets).map((bucketName, index) => {
-        const { bucketFull, levelNames } = tempBuckets[bucketName];
+        const { bucketFull, isFeatured, levelNames } = tempBuckets[bucketName];
         return {
           id: index,
           name: bucketName,
           heading: bucketFull,
+          isFeatured: isFeatured,
           options: this.buildOptions(levelNames),
         };
       });

--- a/server/static/js/src/entry/blast/TopForm.vue
+++ b/server/static/js/src/entry/blast/TopForm.vue
@@ -60,30 +60,6 @@
         </div>
       </div>
 
-      <div class="grid_row grid_wrap--s">
-        <div class="col_6 grid_separator">
-          <text-input
-            :required="false"
-            :store-module="storeModule"
-            :show-error="showErrors"
-            label-text="I am giving because"
-            base-classes="form__text form__text--standard"
-            name="reason"
-          />
-        </div>
-        <div class="col_6 grid_separator">
-          <text-input
-            :required="false"
-            :store-module="storeModule"
-            :show-error="showErrors"
-            label-text="zip code"
-            base-classes="form__text form__text--standard"
-            name="zipcode"
-            inputmode="numeric"
-          />
-        </div>
-      </div>
-
       <div class="grid_row grid_separator">
         <div class="col">
           <pay-fees :store-module="storeModule" base-classes="form__fees" />
@@ -131,7 +107,7 @@
                 :form-is-valid="isValid && card.isValid"
                 :is-fetching-token="isFetchingToken"
                 base-classes="form__submit button button--yellow button--l"
-                value="Donate"
+                value="Activate"
                 @setLocalValue="setLocalValue"
                 @setCardValue="setCardValue"
                 @onSubmit="onSubmit"

--- a/server/static/js/src/entry/blast/TopForm.vue
+++ b/server/static/js/src/entry/blast/TopForm.vue
@@ -1,0 +1,213 @@
+<template>
+  <form
+    ref="form"
+    action="/blast"
+    method="post"
+    class="form blast-form"
+    @submit="$event.preventDefault()"
+  >
+    <div v-show="serverErrorMessage" class="grid_container--l grid_separator">
+      <div class="grid_row">
+        <div class="col">
+          <p class="form__error form__error--prominent">
+            {{ serverErrorMessage }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid_container--l grid_separator">
+      <div class="grid_row">
+        <div class="col">
+          <form-buckets :all-levels="allLevels" :store-module="storeModule" />
+        </div>
+      </div>
+    </div>
+
+    <div class="grid_container--m">
+      <div class="grid_row grid_separator">
+        <div class="col">
+          <text-input
+            :store-module="storeModule"
+            :show-error="showErrors"
+            label-text="email address"
+            type="email"
+            base-classes="form__text form__text--standard"
+            name="stripeEmail"
+            inputmode="email"
+          />
+        </div>
+      </div>
+
+      <div class="grid_row grid_wrap--s">
+        <div class="col_6 grid_separator">
+          <text-input
+            :store-module="storeModule"
+            :show-error="showErrors"
+            label-text="first name"
+            base-classes="form__text form__text--standard"
+            name="first_name"
+          />
+        </div>
+        <div class="col_6 grid_separator">
+          <text-input
+            :store-module="storeModule"
+            :show-error="showErrors"
+            label-text="last name"
+            base-classes="form__text form__text--standard"
+            name="last_name"
+          />
+        </div>
+      </div>
+
+      <div class="grid_row grid_wrap--s">
+        <div class="col_6 grid_separator">
+          <text-input
+            :required="false"
+            :store-module="storeModule"
+            :show-error="showErrors"
+            label-text="I am giving because"
+            base-classes="form__text form__text--standard"
+            name="reason"
+          />
+        </div>
+        <div class="col_6 grid_separator">
+          <text-input
+            :required="false"
+            :store-module="storeModule"
+            :show-error="showErrors"
+            label-text="zip code"
+            base-classes="form__text form__text--standard"
+            name="zipcode"
+            inputmode="numeric"
+          />
+        </div>
+      </div>
+
+      <div class="grid_row grid_separator">
+        <div class="col">
+          <pay-fees :store-module="storeModule" base-classes="form__fees" />
+        </div>
+      </div>
+
+      <div class="grid_row">
+        <div class="col">
+          <native-pay
+            :store-module="storeModule"
+            :form-is-valid="isValid"
+            :supported="nativeIsSupported"
+            base-classes="form__native"
+            @setLocalValue="setLocalValue"
+            @setCardValue="setCardValue"
+            @onSubmit="onSubmit"
+          />
+        </div>
+      </div>
+
+      <div
+        v-if="nativeIsSupported && showManualPay"
+        class="grid_separator--l"
+        aria-hidden="true"
+      />
+
+      <div
+        :aria-live="nativeIsSupported ? 'polite' : false"
+        class="grid_separator"
+      >
+        <div v-if="showManualPay">
+          <div class="grid_row">
+            <div class="col">
+              <manual-pay
+                :card="card"
+                base-classes="form__manual"
+                @setCardValue="setCardValue"
+              />
+            </div>
+          </div>
+
+          <div class="grid_row">
+            <div class="col">
+              <manual-submit
+                :form-is-valid="isValid && card.isValid"
+                :is-fetching-token="isFetchingToken"
+                base-classes="form__submit button button--yellow button--l"
+                value="Donate"
+                @setLocalValue="setLocalValue"
+                @setCardValue="setCardValue"
+                @onSubmit="onSubmit"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="genericErrorMessage" class="grid_separator">
+        <div class="grid_row">
+          <div class="col">
+            <p
+              role="alert"
+              class="form__error form__error--normal form__error--centered"
+            >
+              {{ genericErrorMessage }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <p class="subtext">
+        This site is protected by reCAPTCHA and the Google
+        <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+        <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+      </p>
+
+      <local-hidden :value="stripeToken" name="stripeToken" />
+      <local-hidden :value="recaptchaToken" name="recaptchaToken" />
+      <hidden name="amount" :store-module="storeModule" />
+      <hidden name="level" :store-module="storeModule" />
+      <hidden name="installment_period" :store-module="storeModule" />
+      <hidden name="description" :store-module="storeModule" />
+      <hidden name="campaign_id" :store-module="storeModule" />
+      <hidden name="referral_id" :store-module="storeModule" />
+      <hidden name="pay_fees_value" :store-module="storeModule" />
+    </div>
+  </form>
+</template>
+
+<script>
+import Hidden from '../../connected-elements/Hidden.vue';
+import PayFees from '../../connected-elements/PayFees.vue';
+import TextInput from '../../connected-elements/TextInput.vue';
+import FormBuckets from '../../connected-elements/FormBuckets.vue';
+import ManualPay from '../../payment-elements/ManualPay.vue';
+import ManualSubmit from '../../payment-elements/ManualSubmit.vue';
+import NativePay from '../../payment-elements/NativePay.vue';
+import LocalHidden from '../../local-elements/Hidden.vue';
+import formStarter from '../../mixins/connected-form/starter';
+import { BLAST_LEVELS } from './constants';
+
+export default {
+  name: 'TopForm',
+
+  components: {
+    Hidden,
+    LocalHidden,
+    TextInput,
+    PayFees,
+    ManualPay,
+    ManualSubmit,
+    NativePay,
+    FormBuckets,
+  },
+
+  mixins: [formStarter],
+
+  data() {
+    return {
+      // eslint-disable-next-line no-underscore-dangle
+      serverErrorMessage: window.__TOP_FORM_SERVER_ERROR_MESSAGE__,
+      storeModule: 'blastForm',
+      allLevels: BLAST_LEVELS,
+    };
+  },
+};
+</script>

--- a/server/static/js/src/entry/blast/TopForm.vue
+++ b/server/static/js/src/entry/blast/TopForm.vue
@@ -18,7 +18,7 @@
 
     <div class="grid_container--l grid_separator">
       <div class="grid_row">
-        <div class="col">
+        <div class="col blast-buckets">
           <form-buckets :all-levels="allLevels" :store-module="storeModule" />
         </div>
       </div>

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -72,7 +72,7 @@ export const BLAST_FORM_STATE = {
     message: null,
   },
   description: {
-    value: 'The Texas Tribune Circle Membership',
+    value: 'The Blast Subscription',
     isValid: true,
     validator: null,
     message: null,

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -38,11 +38,11 @@ export const BLAST_LEVELS = {
   blastLegislativeSession: {
     bucket: 'legislative',
     bucketFull: 'Legislative session-only',
-    installmentPeriod: 'session',
+    installmentPeriod: 'one-time',
     amount: '200',
     isFeatured: true,
     prompt: 'Get ahead with insider news!',
-    footer: 'January 17 – June 17',
+    footer: 'January 14 – June 14',
   },
 };
 

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -1,0 +1,97 @@
+import * as validators from '../../utils/validators';
+
+export const DEFAULT_LEVEL = 'blastMonthly';
+
+export const BLAST_LEVELS = {
+  blastMonthly: {
+    bucket: 'standard',
+    bucketFull: 'Standard subscription',
+    installmentPeriod: 'monthly',
+    amount: '40',
+  },
+  blastYearly: {
+    bucket: 'standard',
+    bucketFull: 'Standard subscription',
+    installmentPeriod: 'yearly',
+    amount: '349',
+  },
+  blastTaxExemptYearly: {
+    bucket: 'tax-exempt',
+    bucketFull: 'Tax-exempt subscription',
+    installmentPeriod: 'yearly',
+    amount: '325',
+  },
+  blastAcademicMonthly: {
+    bucket: 'academic',
+    bucketFull: 'Academic discount',
+    installmentPeriod: 'monthly',
+    amount: '20',
+  },
+  blastAcademicYearly: {
+    bucket: 'academic',
+    bucketFull: 'Academic discount',
+    installmentPeriod: 'yearly',
+    amount: '199',
+  },
+  blastLegislativeYearly: {
+    bucket: 'legislative',
+    bucketFull: 'Legislative session-only',
+    installmentPeriod: 'yearly',
+    amount: '240',
+  },
+};
+
+export const BLAST_FORM_STATE = {
+  stripeEmail: {
+    value: '',
+    isValid: false,
+    validator: validators.isEmail,
+    message: 'Enter a valid email address',
+  },
+  first_name: {
+    value: '',
+    isValid: false,
+    validator: validators.isNotEmpty,
+    message: 'Enter your first name',
+  },
+  last_name: {
+    value: '',
+    isValid: false,
+    validator: validators.isNotEmpty,
+    message: 'Enter your last name',
+  },
+  reason: {
+    value: '',
+    isValid: false,
+    validator: validators.isMaxLength(255),
+    message: 'Must be 255 characters or fewer',
+  },
+  zipcode: {
+    value: '',
+    isValid: false,
+    validator: validators.isEmptyOrZip,
+    message: 'Enter a 5-digit zip code',
+  },
+  pay_fees_value: {
+    value: 'False',
+    isValid: true,
+    validator: null,
+    message: null,
+  },
+  description: {
+    value: 'The Texas Tribune Circle Membership',
+    isValid: true,
+    validator: null,
+    message: null,
+  },
+  installment_period: {
+    value: '',
+    isValid: true,
+    validator: null,
+    message: null,
+  },
+  level: { value: '', isValid: true, validator: null, message: null },
+  campaign_id: { value: '', isValid: true, validator: null, message: null },
+  referral_id: { value: '', isValid: true, validator: null, message: null },
+  amount: { value: '', isValid: true, validator: null, message: null },
+};

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -15,7 +15,7 @@ export const BLAST_LEVELS = {
     installmentPeriod: 'yearly',
     amount: '349',
   },
-  blastTaxExemptYearly: {
+  blastTaxExempt: {
     bucket: 'tax-exempt',
     bucketFull: 'Tax-exempt subscription',
     installmentPeriod: 'yearly',
@@ -33,10 +33,10 @@ export const BLAST_LEVELS = {
     installmentPeriod: 'yearly',
     amount: '199',
   },
-  blastLegislativeYearly: {
+  blastLegislativeSession: {
     bucket: 'legislative',
     bucketFull: 'Legislative session-only',
-    installmentPeriod: 'yearly',
+    installmentPeriod: 'session',
     amount: '240',
   },
 };
@@ -59,18 +59,6 @@ export const BLAST_FORM_STATE = {
     isValid: false,
     validator: validators.isNotEmpty,
     message: 'Enter your last name',
-  },
-  reason: {
-    value: '',
-    isValid: false,
-    validator: validators.isMaxLength(255),
-    message: 'Must be 255 characters or fewer',
-  },
-  zipcode: {
-    value: '',
-    isValid: false,
-    validator: validators.isEmptyOrZip,
-    message: 'Enter a 5-digit zip code',
   },
   pay_fees_value: {
     value: 'False',

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -42,7 +42,7 @@ export const BLAST_LEVELS = {
     amount: '200',
     isFeatured: true,
     prompt: 'Get ahead with insider news!',
-    footer: 'January 17 - June 17',
+    footer: 'January 17 – June 17',
   },
 };
 

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -21,23 +21,24 @@ export const BLAST_LEVELS = {
     installmentPeriod: 'yearly',
     amount: '325',
   },
-  blastAcademicMonthly: {
-    bucket: 'academic',
-    bucketFull: 'Academic discount',
-    installmentPeriod: 'monthly',
-    amount: '20',
-  },
-  blastAcademicYearly: {
-    bucket: 'academic',
-    bucketFull: 'Academic discount',
-    installmentPeriod: 'yearly',
-    amount: '199',
-  },
+  // blastAcademicMonthly: {
+  //   bucket: 'academic',
+  //   bucketFull: 'Academic discount',
+  //   installmentPeriod: 'monthly',
+  //   amount: '20',
+  // },
+  // blastAcademicYearly: {
+  //   bucket: 'academic',
+  //   bucketFull: 'Academic discount',
+  //   installmentPeriod: 'yearly',
+  //   amount: '199',
+  // },
   blastLegislativeSession: {
     bucket: 'legislative',
     bucketFull: 'Legislative session-only',
     installmentPeriod: 'session',
-    amount: '240',
+    amount: '200',
+    isFeatured: true,
   },
 };
 

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -8,6 +8,8 @@ export const BLAST_LEVELS = {
     bucketFull: 'Standard subscription',
     installmentPeriod: 'monthly',
     amount: '40',
+    isDefault: true,
+    footer: 'Save 27% with yearly',
   },
   blastYearly: {
     bucket: 'standard',
@@ -39,6 +41,8 @@ export const BLAST_LEVELS = {
     installmentPeriod: 'session',
     amount: '200',
     isFeatured: true,
+    prompt: 'Get ahead with insider news!',
+    footer: 'January 17 - June 17',
   },
 };
 

--- a/server/static/js/src/entry/blast/index.js
+++ b/server/static/js/src/entry/blast/index.js
@@ -1,0 +1,22 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+import App from '../../App.vue';
+import connectedFormModule from '../../store/modules/connected-form';
+import { createRouter, bindRouterEvents } from './router';
+import cssClasses from '../../mixins/global/css-classes';
+import gtm from '../../mixins/global/gtm';
+
+Vue.use(Vuex);
+Vue.mixin(cssClasses);
+Vue.mixin(gtm);
+
+const store = new Vuex.Store({
+  modules: {
+    blastForm: connectedFormModule,
+  },
+});
+const router = createRouter();
+const routeHandler = new Vue({ ...App, router });
+
+bindRouterEvents(router, routeHandler, store);

--- a/server/static/js/src/entry/blast/router.js
+++ b/server/static/js/src/entry/blast/router.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-underscore-dangle */
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+
+import RouteHandler from '../../RouteHandler.vue';
+import TopForm from './TopForm.vue';
+import mergeValuesIntoStartState from '../../utils/merge-values-into-start-state';
+import sanitizeParams from '../../utils/sanitize-params';
+import { BLAST_LEVELS, BLAST_FORM_STATE, DEFAULT_LEVEL } from './constants';
+
+Vue.use(VueRouter);
+
+function getStateFromParams(queryParams) {
+  const cleanParams = sanitizeParams(queryParams);
+  let { level = "" } = cleanParams;
+  const {
+    campaignId = '',
+    referralId = '',
+    firstName = '',
+    lastName = '',
+    email = '',
+    zipcode = '',
+  } = cleanParams;
+
+  if (!BLAST_LEVELS[level]) level = DEFAULT_LEVEL;
+
+  const { amount, installmentPeriod } = BLAST_LEVELS[level];
+
+  return {
+    level,
+    amount,
+    zipcode,
+    first_name: firstName,
+    last_name: lastName,
+    stripeEmail: email,
+    installment_period: installmentPeriod,
+    campaign_id: campaignId,
+    referral_id: referralId,
+  };
+}
+
+function createInitialFormState(queryParams) {
+  // if form submission was invalid,
+  // rehydrate the store from the JSON blob in the template
+  if (window.__BLAST_FORM_REHYDRATION__) {
+    return mergeValuesIntoStartState(
+      BLAST_FORM_STATE,
+      window.__BLAST_FORM_REHYDRATION__
+    );
+  }
+
+  const paramState = getStateFromParams(queryParams);
+  // merge query-parameter values into full state object,
+  // which contains validation information
+  return mergeValuesIntoStartState(BLAST_FORM_STATE, paramState);
+}
+
+function createRouter() {
+  return new VueRouter({
+    base: '/blast',
+    mode: 'history',
+    routes: [{ path: '/', component: RouteHandler }],
+  });
+}
+
+function bindRouterEvents(router, routeHandler, store) {
+  router.onReady(() => {
+    const topForm = new Vue({ ...TopForm, store });
+    const {
+      currentRoute: { query },
+    } = router;
+
+    store.dispatch(
+      'blastForm/createInitialState',
+      createInitialFormState(query)
+    );
+
+    routeHandler.$mount('#app');
+    topForm.$mount('#blast-form');
+  });
+}
+
+export { createRouter, bindRouterEvents };

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -30,7 +30,7 @@
   &__prompt {
     @include font-setting('secondary');
     position: absolute;
-    top: 0;
+    bottom: 100%;
     font-size: $size-xs;
     font-weight: bold;
   }
@@ -60,5 +60,8 @@
 .blast-buckets {
   .form-buckets__item {
     padding-bottom: 4rem;
+  }
+  div.form-buckets__item {
+    overflow: visible;
   }
 }

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -30,7 +30,7 @@
   &__prompt {
     @include font-setting('secondary');
     position: absolute;
-    bottom: 100%;
+    top: 0;
     font-size: $size-xs;
     font-weight: bold;
   }

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -2,26 +2,53 @@
 
   &__item {
     border-width: 3px;
-    border-color: $color-white-off;
     border-style: solid;
-    padding: $size-s;
+    padding: $size-s $size-s $size-l;
     transition: border-color 0.2s;
     
     &--selected {
       border-color: $color-yellow-tribune;
+
+      &_border_bottom {
+        border-bottom: 2rem solid $color-yellow-tribune;
+      }
     }
 
+    &--unselected {
+      border-color: $color-white-off;
+
+      &_border_bottom {
+        border-bottom: 2rem solid $color-white-off;
+      }
+    }
+  
     &--featured {
       border-color: $color-blue-light;
+      border-bottom: 2rem solid $color-blue-light;
     }
   }
   
-
-
   &__header {
     @include font-setting('secondary');
     font-size: $size-l;
     font-weight: bold;
     line-height: 1;
+  }
+
+  &__prompt {
+    @include font-setting('secondary');
+    position: absolute;
+    top: 23.5rem;
+    font-size: $size-xs;
+    font-weight: bold;
+  }
+
+  &__footer {
+    @include font-setting('secondary');
+    position: absolute;
+    top: 35.75rem;
+    font-size: $size-m;
+    font-weight: bold;
+    text-align: center;
   }
 }

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -28,10 +28,9 @@
   }
 
   &__prompt {
-    @include font-setting('secondary');
     position: absolute;
-    bottom: 100%;
-    font-size: $size-xs;
+    bottom: 102%;
+    font-size: $size-s;
     font-weight: bold;
   }
 

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -28,10 +28,18 @@
   }
 
   &__prompt {
-    position: absolute;
-    bottom: 102%;
+    left: 0;
+    bottom: 100%;
     font-size: $size-s;
     font-weight: bold;
+    padding-bottom: .5rem;
+    width: 100%;
+    text-align: left;
+
+    @include mq($from: bp-m) {
+      text-align: center;
+      position: absolute;
+    }
   }
 
   &__footer {
@@ -57,6 +65,10 @@
 
 
 .blast-buckets {
+  // add spacing for value prop
+  @include mq($from: bp-m) {
+    margin-top: $size-l;
+  }
   .form-buckets__item {
     padding-bottom: 4rem;
   }

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -5,29 +5,21 @@
     border-style: solid;
     padding: $size-s $size-s $size-l;
     transition: border-color 0.2s;
-    
+    position: relative;
+
     &--selected {
       border-color: $color-yellow-tribune;
-
-      &_border_bottom {
-        border-bottom: 2rem solid $color-yellow-tribune;
-      }
     }
 
     &--unselected {
       border-color: $color-white-off;
-
-      &_border_bottom {
-        border-bottom: 2rem solid $color-white-off;
-      }
     }
-  
+
     &--featured {
       border-color: $color-blue-light;
-      border-bottom: 2rem solid $color-blue-light;
     }
   }
-  
+
   &__header {
     @include font-setting('secondary');
     font-size: $size-l;
@@ -38,17 +30,35 @@
   &__prompt {
     @include font-setting('secondary');
     position: absolute;
-    top: 23.5rem;
+    bottom: 100%;
     font-size: $size-xs;
     font-weight: bold;
   }
 
   &__footer {
-    @include font-setting('secondary');
+    text-transform: uppercase;
+    letter-spacing: .02em;
+    background-color: $color-yellow-tribune;
     position: absolute;
-    top: 35.75rem;
-    font-size: $size-m;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    font-size: $size-b;
     font-weight: bold;
     text-align: center;
+    padding: .5rem;
+  }
+
+  &__item--featured {
+    .form-buckets__footer {
+      background: $color-blue-light;
+    }
+  }
+}
+
+
+.blast-buckets {
+  .form-buckets__item {
+    padding-bottom: 4rem;
   }
 }

--- a/server/static/sass/6-components/_form-buckets.scss
+++ b/server/static/sass/6-components/_form-buckets.scss
@@ -10,6 +10,10 @@
     &--selected {
       border-color: $color-yellow-tribune;
     }
+
+    &--featured {
+      border-color: $color-blue-light;
+    }
   }
   
 

--- a/server/static/sass/blast.scss
+++ b/server/static/sass/blast.scss
@@ -1,0 +1,22 @@
+@import 'ds-toolbox-base';
+
+@import '1-settings/all';
+@import '2-tools/all';
+@import '3-generic/all';
+@import '4-elements/all';
+
+// Include components & typography as needed
+@import '5-typography/links';
+@import '5-typography/typography';
+
+@import '6-components/buttons';
+@import '6-components/contact';
+@import '6-components/footer';
+@import '6-components/form-buckets';
+@import '6-components/forms';
+@import '6-components/hero';
+@import '6-components/images';
+@import '6-components/wall';
+@import '6-components/splash';
+
+@import '7-utilities/all';

--- a/server/templates/blast-form-legacy.html
+++ b/server/templates/blast-form-legacy.html
@@ -1,0 +1,114 @@
+{% extends "layout.html" %}
+{% block title %}
+  The Blast | The Texas Tribune
+{% endblock %}
+{% block extra_script %}
+<script src="{{ url_for('static', filename='js/blast.js') }}"></script>
+{% endblock %}
+
+{% block og_meta %}
+  <meta property="og:url" content="https://support.texastribune.org/blastform">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-blast.png') }}">
+  <meta property="og:title" content="The Blast | The Texas Tribune">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on happenings in the Capitol three times a week for insiders. Don’t get left behind. Subscribe today.">
+  <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
+{% block content %}
+
+  <section class="splash splash--blast">
+    <div class="grid_container grid_row grid_padded grid_wrap--m align-bottom">
+      <figure class="col col_5--m">
+        <a class="splash__logo" href="https://www.texastribune.org/theblast/" class="unlink"><img src="{{ url_for('static', filename='img/c-blast-header-backup-logo.png') }}"
+            alt="The Blast logo, a product of The Texas Tribune"></a>
+      </figure>
+      <div class="col col_7--m splash__bug">
+        <img src="{{ url_for('static', filename='img/TT-aprojectby.svg')}}" alt="A project by The Texas Tribune">
+      </div>
+    </div>
+  </section>
+  <div id="blast" class="grid_container blast_main">
+    <form action="/submit-blast" method="post" class="blastform grid_separator--l">
+      <input name="campaign_id" id="campaign_id" value="{{ campaign_id }}" type="hidden">
+      <input name="referral_id" id="referral_id" value="{{ referral_id }}" type="hidden">
+      <input name="level" id="level" type="hidden">
+      <div class="form-outer-section outer-section narrow">
+
+        <header class="grid_separator--l">
+          <h1>Sign up for the best political newsletter in Texas.</h1>
+        </header>
+        <div class="grid_row grid_wrap--l grid_wrap--reverse">
+          <div class="col col_7--xl">
+            <div class="grid_row grid_separator grid_wrap--m">
+              <div class="col_6">
+                {{ form.first_name.label }}<br>
+                  {{ form.first_name(maxlength=50) }}
+              </div>
+              <div class="col_6">
+                {{ form.last_name.label }}<br>
+                  {{ form.last_name(maxlength=50) }}
+              </div>
+            </div>
+            <div class="grid_row">
+              <div class="col">
+                {{ form.subscriber_email.label }}
+                  {{ form.subscriber_email(maxlength=70) }}
+                  <p class="form-subtext">&raquo; You will be prompted for the billing email address at checkout.</p>
+              </div>
+            </div>
+            <div class="grid_row">
+              <div class="col col_9--l">
+                {{ form.pay_fees.label }}
+                  {{ form.pay_fees(checked=False) }}
+                <p id="pay-fee-amount" class="label-info"><span></span></p>
+                <p id="pay-fee-info">Paying these fees directs more money in support of the Tribune’s mission.</p>
+              </div>
+            </div>
+            {{ form.pay_fees_value(value="False") }}
+            {{ form.installment_period(value=installment_period) }}
+            <div class="form-section form-error">
+              <p class="error-form-message"></p>
+            </div>
+          </div>
+          <div class="col col_5--xl form__box grid_separator">
+            <ul class="subscription grid_row">
+              {% for subfield in form.amount %}
+              <li class="col grid_separator">
+              <tr>
+                  <td>{{ subfield }}</td>
+                  <td>{{ subfield.label }}</td>
+              </tr>
+              </li>
+              {% endfor %}
+            </ul>
+            <h4 class="grid_separator--s">Would multiple people at your organization like to receive The Blast? Good news! We offer group rates.</h4>
+            <p class="subtext">Email us at <a href="mailto:blast@texastribune.org">blast@texastribune.org</a> or call <a href="tel:+15127168695">512-993-0166</a> for more information.</p>
+          </div>
+        </div>
+        {{ form.description(value='Blast Subscription') }}
+        <script src="https://checkout.stripe.com/checkout.js"></script>
+        <button id="customButton" class="button button-flat button--yellow button--l">Submit</button>
+      </div>
+    </form>
+
+
+    {% include 'includes/blast_stripe_checkout_js.html' %}
+  </div>
+  <script>
+    window.onload = function() {
+      payFeeAmount();
+      listen_for_fee_check();
+    };
+
+    $('input[name="amount"]').change(function() {
+      payFeeAmount();
+      $('input[name="amount"]').each(function() {
+        $(this).attr("checked", false);
+      });
+      $(this).attr("checked", "checked");
+      $(this).prop("checked", true);
+    });
+
+  </script>
+{% endblock %}

--- a/server/templates/blast-form.html
+++ b/server/templates/blast-form.html
@@ -1,114 +1,114 @@
-{% extends "layout.html" %}
-{% block title %}
-  The Blast | The Texas Tribune
-{% endblock %}
-{% block extra_script %}
-<script src="{{ url_for('static', filename='js/blast.js') }}"></script>
-{% endblock %}
+{% extends "new_layout.html" %}
+
+{% block title %}The Blast | The Texas Tribune{% endblock %}
 
 {% block og_meta %}
-  <meta property="og:url" content="https://support.texastribune.org/blastform">
+  <meta property="og:url" content="https://support.texastribune.org/blast">
   <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-blast.png') }}">
   <meta property="og:title" content="The Blast | The Texas Tribune">
   <meta property="og:type" content="website">
-  <meta property="og:description" content="The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on happenings in the Capitol three times a week for insiders. Don’t get left behind. Subscribe today.">
-  <meta name="twitter:card" content="summary_large_image">
+  <meta property="og:description" content="The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on political moves across the state for insiders like you.">
+{% endblock %}
+
+{% block head_scripts %}
+{% if form_data and message %}
+<script>
+  window.location.replace('#join-today');
+</script>
+{% endif %}
 {% endblock %}
 
 {% block content %}
+  <main class="main">
+    <!-- where the router component attaches -->
+    <div id="app" style="display:none;"></div>
 
-  <section class="splash splash--blast">
-    <div class="grid_container grid_row grid_padded grid_wrap--m align-bottom">
-      <figure class="col col_5--m">
-        <a class="splash__logo" href="https://www.texastribune.org/theblast/" class="unlink"><img src="{{ url_for('static', filename='img/c-blast-header-backup-logo.png') }}"
-            alt="The Blast logo, a product of The Texas Tribune"></a>
-      </figure>
-      <div class="col col_7--m splash__bug">
-        <img src="{{ url_for('static', filename='img/TT-aprojectby.svg')}}" alt="A project by The Texas Tribune">
+    <section class="splash splash--blast">
+      <div class="grid_container grid_row grid_padded grid_wrap--m align-bottom">
+        <figure class="col col_5--m">
+          <a class="splash__logo" href="https://www.texastribune.org/theblast/" class="unlink"><img src="{{ url_for('static', filename='img/c-blast-header-backup-logo.png') }}"
+              alt="The Blast logo, a product of The Texas Tribune"></a>
+        </figure>
+        <div class="col col_7--m splash__bug">
+          <img src="{{ url_for('static', filename='img/TT-aprojectby.svg')}}" alt="A project by The Texas Tribune">
+        </div>
       </div>
-    </div>
-  </section>
-  <div id="blast" class="grid_container blast_main">
-    <form action="/submit-blast" method="post" class="blastform grid_separator--l">
-      <input name="campaign_id" id="campaign_id" value="{{ campaign_id }}" type="hidden">
-      <input name="referral_id" id="referral_id" value="{{ referral_id }}" type="hidden">
-      <input name="level" id="level" type="hidden">
-      <div class="form-outer-section outer-section narrow">
+    </section>
 
-        <header class="grid_separator--l">
-          <h1>Sign up for the best political newsletter in Texas.</h1>
-        </header>
-        <div class="grid_row grid_wrap--l grid_wrap--reverse">
-          <div class="col col_7--xl">
-            <div class="grid_row grid_separator grid_wrap--m">
-              <div class="col_6">
-                {{ form.first_name.label }}<br>
-                  {{ form.first_name(maxlength=50) }}
-              </div>
-              <div class="col_6">
-                {{ form.last_name.label }}<br>
-                  {{ form.last_name(maxlength=50) }}
-              </div>
-            </div>
-            <div class="grid_row">
-              <div class="col">
-                {{ form.subscriber_email.label }}
-                  {{ form.subscriber_email(maxlength=70) }}
-                  <p class="form-subtext">&raquo; You will be prompted for the billing email address at checkout.</p>
-              </div>
-            </div>
-            <div class="grid_row">
-              <div class="col col_9--l">
-                {{ form.pay_fees.label }}
-                  {{ form.pay_fees(checked=False) }}
-                <p id="pay-fee-amount" class="label-info"><span></span></p>
-                <p id="pay-fee-info">Paying these fees directs more money in support of the Tribune’s mission.</p>
-              </div>
-            </div>
-            {{ form.pay_fees_value(value="False") }}
-            {{ form.installment_period(value=installment_period) }}
-            <div class="form-section form-error">
-              <p class="error-form-message"></p>
-            </div>
+    <div class="grid_container grid_padded--xl">
+      <section class="section-padding print__hide">
+        <header class="circle-donate__header grid_container--m grid_separator">
+          <div class="border--yellow_notch"></div>
+          <h2 class="circle-donate__hed grid_separator">The best political newsletter in Texas.</h2>
+          <div class="prose grid_separator--xl">
+            <p>The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on political moves across the state for insiders like you.</p>
           </div>
-          <div class="col col_5--xl form__box grid_separator">
-            <ul class="subscription grid_row">
-              {% for subfield in form.amount %}
-              <li class="col grid_separator">
-              <tr>
-                  <td>{{ subfield }}</td>
-                  <td>{{ subfield.label }}</td>
-              </tr>
-              </li>
-              {% endfor %}
-            </ul>
-            <h4 class="grid_separator--s">Would multiple people at your organization like to receive The Blast? Good news! We offer group rates.</h4>
-            <p class="subtext">Email us at <a href="mailto:blast@texastribune.org">blast@texastribune.org</a> or call <a href="tel:+15127168695">512-993-0166</a> for more information.</p>
+        </header>
+        <!-- for hash links when a form is invalid -->
+        <div id="join-today"></div>
+        <!-- where the form attaches -->
+        <div id="blast-form"></div>
+      </section>
+
+      <section class="grid_container--m section-padding grid_padded print__hide">
+        <header>
+          <div class="border--yellow_notch"></div>
+          <h2 class="grid_separator circle-benefits__header">Questions?</h2>
+        </header>
+        <div class="contact grid_row grid_wrap--l grid_separator">
+          <div class="col">
+            <p class="grid_separator--s">For Blast questions, contact:</p>
+            <p><strong>Matthew Watkins</strong></p>
+            <p>Editor in Chief</p>
+            <p class="grid_separator"><a href="mailto:mwatkins@texastribune.org">mwatkins@texastribune.org</a></p>
+          </div>
+          <div class="col">
+            <p class="grid_separator--s">For <a href="https://www.texastribune.org/support-us/corporate-sponsors/">corporate sponsorships</a> and business membership, contact:</p>
+            <p><strong>April Hinkle</strong></p>
+            <p>Chief Revenue Officer</p>
+            <p>512-716-8634</p>
+            <p><a href="mailto:ahinkle@texastribune.org">ahinkle@texastribune.org</a></p>
           </div>
         </div>
-        {{ form.description(value='Blast Subscription') }}
-        <script src="https://checkout.stripe.com/checkout.js"></script>
-        <button id="customButton" class="button button-flat button--yellow button--l">Submit</button>
-      </div>
-    </form>
+        <div class="contact grid_row grid_wrap--l grid_separator--l">
+          <div class="col">
+            <p class="grid_separator--s">For other membership questions, contact:</p>
+            <p>512-993-0166</p>
+            <p class="grid_separator"><a href="mailto:membership@texastribune.org">membership@texastribune.org</a></p>
+          </div>
+        </div>
+      </section>
 
+    </div>
+  </main>
+{% endblock %}
 
-    {% include 'includes/blast_stripe_checkout_js.html' %}
-  </div>
+{% block bottom_script %}
   <script>
-    window.onload = function() {
-      payFeeAmount();
-      listen_for_fee_check();
-    };
-
-    $('input[name="amount"]').change(function() {
-      payFeeAmount();
-      $('input[name="amount"]').each(function() {
-        $(this).attr("checked", false);
-      });
-      $(this).attr("checked", "checked");
-      $(this).prop("checked", true);
-    });
-
+    window.__STRIPE_KEY__ = '{{ stripe }}';
+    window.__RECAPTCHA_KEY__ = '{{ recaptcha }}';
   </script>
+
+  {% if form_data and message %}
+  <script>
+    window.__TOP_FORM_SERVER_ERROR_MESSAGE__ = {{ message|tojson }};
+    window.__BLAST_FORM_REHYDRATION__ = {{ form_data|tojson }};
+  </script>
+  {% endif %}
+
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="https://www.google.com/recaptcha/api.js?render={{ recaptcha }}"></script>
+  <script>
+    !function () {
+      var script = document.createElement('script');
+      script.async = true;
+      script.src = 'https://risk.clearbit.com/v1/risk.js';
+      var parent = document.getElementsByTagName('script')[0];
+      parent.parentNode.insertBefore(script, parent);
+    }();
+  </script>
+
+  {% for script in bundles['js'] %}
+    <script src="{{ script }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/server/templates/blast-form.html
+++ b/server/templates/blast-form.html
@@ -37,9 +37,9 @@
 
     <div class="grid_container grid_padded--xl">
       <section class="section-padding print__hide">
-        <header class="circle-donate__header grid_container--m grid_separator">
+        <header class="grid_container--m grid_separator">
           <div class="border--yellow_notch"></div>
-          <h2 class="circle-donate__hed grid_separator">The best political newsletter in Texas.</h2>
+          <h2 class="grid_separator">The best political newsletter in Texas.</h2>
           <div class="prose grid_separator--xl">
             <p>The Blast, The Texas Tribune’s premier newsletter, puts to use the full weight of the newsroom’s political team to serve up exclusive reporting, nonpartisan analysis and the first word on political moves across the state for insiders like you.</p>
           </div>
@@ -53,7 +53,7 @@
       <section class="grid_container--m section-padding grid_padded print__hide">
         <header>
           <div class="border--yellow_notch"></div>
-          <h2 class="grid_separator circle-benefits__header">Questions?</h2>
+          <h2 class="grid_separator">Questions?</h2>
         </header>
         <div class="contact grid_row grid_wrap--l grid_separator">
           <div class="col">

--- a/webpack/entries.js
+++ b/webpack/entries.js
@@ -5,6 +5,7 @@ const entriesNames = [
   'charge',
   'circle',
   'business',
+  'blast',
   'waco',
   'old',
   'account',


### PR DESCRIPTION
#### What's this PR do?
Adds a new page/form for Blast subscriptions.

#### Why are we doing this? How does it help us?
We wanted to add some new options for the Blast and creating this page at the same time brings the Blast workflow closer in accordance with the rest of the donations pages.

#### How should this be manually tested?
Visit the blast page on [staging](https://donations-testing.herokuapp.com/blast)
For each option (standard, tax-exempt, academic and legislative), for monthly, yearly or session as applicable...
    * create a new donation
    * check for that donation in stripe (customers/transactions tabs)
        * check that the amount and cadence on the item is accurate
    * check that the donation has synced through to salesforce (can look up by stripe subscription or customer id)
    * on the recurring donation object in salesforce, ensure the subscriber email is listed

#### How should this change be communicated to end users?
I'm assuming this part falls to @ashley-hebler and Ryan Kim, but happy to help as needed.

#### Are there any smells or added technical debt to note?
A few things...
* I spent some time (probably more than I should have) trying to get some stripe elements working here to make the front-end's access to products/prices easier, cleaner and more efficient, but without much luck. When I to have more time, I'd really like to get that working
* The new legislative session-only option is set on a two-year cadence in stripe, which means that the user will only get charged every session (since that's on a two-year cadence as well). There are definitely other ways we could do this (it could just be a one-time charge, if that works) but I felt like this was more in line with the spirit of the option on the front-end (240 per session). The only hang-up here is that, to my knowledge, this same cadence isn't available in SF, so we end up on a yearly cadence there, meaning we would need to manually close those opportunities that pop-up in the off year (2026, 2028). I'll reach out to Anna to see if I missed a way of doing this more properly in SF.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recbnhUrrBplaw7Gn?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
