### PR TITLE
Redirect Broken URL

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -252,6 +252,7 @@ support.texastribune.org.
 @app.route("/index.html")
 @app.route("/memberform")
 @app.route("/donateform")
+@app.route("/donate/")
 def index_html_route():
     return redirect("/donate", code=302)
 

--- a/server/templates/error.html
+++ b/server/templates/error.html
@@ -16,7 +16,7 @@ super() }}
   <h2>{{ message }}</h2>
   <p>
     If you're trying to become a member or make a donation, you can go to
-    <a href="/donate">our membership and donation page</a> for more info on how
+    <a href="/donate?installmentPeriod=monthly&amount=20&campaignId=701Pe00000RKGDyIAP">our membership and donation page</a> for more info on how
     to support us or contact us at
     <a href="mailto:membership@{{ newsroom.domain }}">membership@{{ newsroom.domain }}</a
     >.


### PR DESCRIPTION
#### What's this PR do?
- Adds membership query params to error page.
- Redirects `/donate/` to `/donate`.

#### Why are we doing this? How does it help us?
- Cleanup

#### How should this be manually tested?
- Confirm going to https://support.texastribune.org/donate/ redirects.

#### How should this change be communicated to end users?
- Follow up with Emily.

#### Are there any smells or added technical debt to note?
- Query params are lost during the redirect.

#### What are the relevant tickets?
- Off sprint
