### PR TITLE
fixing payment syncs from email-less donors

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1646,12 +1646,14 @@ def get_contact(customer):
     first_name, last_name = name_splitter(customer.get("name"))
     address = customer.get("address", None)
     zipcode = address.get("postal_code", None) if address else None
+    metadata = customer.get("metadata", {})
     app.logger.info("----Getting contact....")
     contact = Contact.get_or_create(
         email=customer.get("email", None),
         first_name=first_name,
         last_name=last_name,
-        zipcode=zipcode
+        zipcode=zipcode,
+        id=metadata.get("sf_id", None),
     )
 
     # TODO had initially commented out these next two ifs but within a day the "Subscriber Subscriber"

--- a/server/npsp.py
+++ b/server/npsp.py
@@ -1039,8 +1039,8 @@ class Contact(SalesforceObject):
         }
 
     @classmethod
-    def get_or_create(cls, email, first_name=None, last_name=None, zipcode=None):
-        contact = cls.get(email=email)
+    def get_or_create(cls, email, first_name=None, last_name=None, zipcode=None, id=None):
+        contact = cls.get(id=id, email=email)
         if contact:
             logging.debug(f"Contact found: {contact}")
             return contact

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -51,9 +51,10 @@ def generate_header(**kwargs) -> str:
     header = "t=%d,%s=%s" % (timestamp, scheme, signature)
     return header
 
-def mock_contact_get_or_create(email, first_name=None, last_name=None, zipcode=None):
+def mock_contact_get_or_create(email, first_name=None, last_name=None, zipcode=None, id=None):
     print("Creating contact...")
     contact = Contact()
+    contact.id = id
     contact.email = email
     contact.first_name = first_name
     contact.last_name = last_name


### PR DESCRIPTION
#### What's this PR do?
* looks for an sf_id from the customer object coming from stripe (alligned with the contact obect in sf)
* this id can sub for an email on Contact.get() when an email isn't provided

#### Why are we doing this? How does it help us?
We have at least one monthly donor who has no email associated with them and each time they get charged, we hit this bug.

#### How should this be manually tested?
Forewarning... since this is one of those edge case bugs, recreating the set of circumstances that causes it is convoluted... here we go!

* Give a recurring donation on the [staging site](https://donations-testing.herokuapp.com/donate)
* Find the new customer in stripe and go to their customer page (easily found in the Customers tab)
    * <img width="1377" alt="Screen Shot 2025-02-03 at 8 47 35 AM" src="https://github.com/user-attachments/assets/579c8358-f1fd-4536-8800-9adfb1c1e665" />
* On the new customer page, click the drop-down menu to the right of "Create Invoice" and choose "Edit Information"
    * <img width="1374" alt="Screen Shot 2025-02-03 at 8 48 14 AM" src="https://github.com/user-attachments/assets/923f7540-c05f-4afe-8911-7be9b0684a72" />
* Remove the "Account email" address and save the update
    * <img width="592" alt="Screen Shot 2025-02-03 at 8 48 41 AM" src="https://github.com/user-attachments/assets/d377ee90-380d-4589-8fdf-fc254240c015" />
* Choose "Create Payment" on the right and fill out the form (any amount and description are fine)
    * <img width="573" alt="Screen Shot 2025-02-03 at 8 49 49 AM" src="https://github.com/user-attachments/assets/b235aad0-011e-4c91-9385-bdf3b8b943e9" />
* The charge will run fine in stripe but you won't see a message come through in the #tech-test channel
    * now the sync is getting blocked because there is no email to find the Contact by in SF
    * the error may or may not bubble up to #tech-warnings, but you can check the logs in Heroku if you want to see the breakage
* Using the customer id from stripe, get to the donor's Contact page in Salesforce
    * Easiest way to do this is to find the recurring donation listing after running search and clicking the Contact link
    * <img width="1126" alt="Screen Shot 2025-02-03 at 9 03 20 AM" src="https://github.com/user-attachments/assets/832b8369-b886-41ed-8640-59cb7bc97c65" />
* Once on the contact page, find the contact id in the url (it's the random set of characters between "contact" and "view") and copy the id
* Back in stripe, find the "Metadata" section of the customer page and add a new key - "sf_id" with the id you copied as the value
    * <img width="1106" alt="Screen Shot 2025-02-03 at 9 36 44 AM" src="https://github.com/user-attachments/assets/f0cce714-c3b1-47e9-a022-3df2b496ac25" />
* Choose "Create Payment" once more and fill out the form again
* Now the charge should go through AND the sync should make it to #tech-test

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
I don't love having to add the sf_id through the customer metadata, but I do think this is more reliable than trying to find the contact by their name.

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
