### PR TITLE
turn off dynamic amount

### DIFF
--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -266,11 +266,13 @@ export default {
       if (initAltFrequency.includes(frequency)) {
         if (amount === initAmount) {
           amount = initAltAmount;
+          // eslint-disable-next-line no-unused-vars
           needsUpdate = true;
         };
       } else {
         if (amount === initAltAmount) {
           amount = initAmount;
+          // eslint-disable-next-line no-unused-vars
           needsUpdate = true;
         };
       };

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -260,7 +260,7 @@ export default {
       let amount = getter('amount');
       // comment in the next line for testing purposes
       // const abTesting = getter('proof');
-      let needsUpdate = false;
+      const needsUpdate = false;
 
       if (initAltFrequency.includes(frequency)) {
         if (amount === initAmount) {

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -260,6 +260,7 @@ export default {
       let amount = getter('amount');
       // comment in the next line for testing purposes
       // const abTesting = getter('proof');
+      // eslint-disable-next-line no-unused-vars
       let needsUpdate = false;
 
       if (initAltFrequency.includes(frequency)) {

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -274,9 +274,10 @@ export default {
         };
       };
       // only update if the current value matches the initial amount or the initial monthly amount
-      if (needsUpdate) {
-        this.updateValue({ storeModule, key: 'amount', value: amount})
-      };
+      // UPDATE 2/25: turning this off until we can be more forthcoming about the final amount at donation submission
+      // if (needsUpdate) {
+      //   this.updateValue({ storeModule, key: 'amount', value: amount})
+      // };
     },
   }
 

--- a/server/static/js/src/entry/donate/TopForm.vue
+++ b/server/static/js/src/entry/donate/TopForm.vue
@@ -260,27 +260,24 @@ export default {
       let amount = getter('amount');
       // comment in the next line for testing purposes
       // const abTesting = getter('proof');
-      // eslint-disable-next-line no-unused-vars
       let needsUpdate = false;
 
       if (initAltFrequency.includes(frequency)) {
         if (amount === initAmount) {
           amount = initAltAmount;
-          // eslint-disable-next-line no-unused-vars
-          needsUpdate = true;
+          // needsUpdate = true;
         };
       } else {
         if (amount === initAltAmount) {
           amount = initAmount;
-          // eslint-disable-next-line no-unused-vars
-          needsUpdate = true;
+          // needsUpdate = true;
         };
       };
       // only update if the current value matches the initial amount or the initial monthly amount
-      // UPDATE 2/25: turning this off until we can be more forthcoming about the final amount at donation submission
-      // if (needsUpdate) {
-      //   this.updateValue({ storeModule, key: 'amount', value: amount})
-      // };
+      // UPDATE 2/25: effectively turning this off until we can be more forthcoming about the final amount at donation submission
+      if (needsUpdate) {
+        this.updateValue({ storeModule, key: 'amount', value: amount})
+      };
     },
   }
 


### PR DESCRIPTION
#### What's this PR do?
Changing frequency of donations will no longer trigger an amount change. 

#### Why are we doing this? How does it help us?
We'll keep this turned off until we have a better way to display the final amount at time of charge. This will hopefully curb the issues we are seeing with donors accidentally giving more than they intend to.

#### How should this be manually tested?
* Spin up locally
* Hit /donate
* Changing between "Monthly donation", "Yearly donation" and "One-time donation" should have no effect on the amount

#### How should this change be communicated to end users?
I'll let Morgan and Emily know

#### Are there any smells or added technical debt to note?
We want to eventually turn this off when we have better displaying of the final amount.

#### What are the relevant tickets?