### PR TITLE
Move benefits to flatpage

### DIFF
--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -73,14 +73,14 @@
           <div class="col_5">
             {% include 'includes/faq.html' %}
           </div>
-          <div class="col_7">
+          <!-- <div class="col_7">
             {% include 'includes/benefits.html' %}
-          </div>
+          </div> -->
         </div>
-      {% else %}
+      <!-- {% else %}
         <div class="member_benefits grid_container">
           {% include 'includes/benefits.html' %}
-        </div>
+        </div> -->
       {% endif %}
     </section>
   </main>

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -77,8 +77,8 @@
             {% include 'includes/benefits.html' %}
           </div> -->
         </div>
-      <!-- {% else %}
-        <div class="member_benefits grid_container">
+      {% else %}
+        <!-- <div class="member_benefits grid_container">
           {% include 'includes/benefits.html' %}
         </div> -->
       {% endif %}

--- a/server/templates/includes/faq.html
+++ b/server/templates/includes/faq.html
@@ -4,14 +4,15 @@
     <li class="c-faq__item">
       <details>
         <summary class="c-faq__summary l-pos-rel gtm-custom-qa-dropdown" data-qa-title="FAQ" data-qa-question="How do I know if I’m a Texas Tribune member?">
-          <h3 class="t-size-s">How do I know if I’m a Texas Tribune member?</h3>
+          <h3 class="t-size-s">What is a Texas Tribune member?</h3>
           <span class="c-icon c-icon--baseline t-size-xs c-faq__icon c-icon l-height-full l-pos-abs">
             <svg aria-hidden="true">
               <use href="#caret-down"></use>
             </svg>
           </span>
         </summary>
-        <p class="t-serif has-b-btm-marg">Your membership is current if you have made a donation of at least $1 within the past 365 days, including if you have an active yearly or monthly donation. Your membership is considered lapsed one year from your last donation.</p>
+        <p class="t-serif has-b-btm-marg">A Texas Tribune member is anyone who has made a donation of any amount within the past 365 days. A membership is considered lapsed one year from your last donation.</p>
+        <p class="t-serif has-b-btm-marg">Check your membership status by creating an account at <a href="http://texastribune.org/signup">texastribune.org/signup</a>.</p>
       </details>
     </li>
     <li class="c-faq__item">
@@ -37,9 +38,9 @@
             </svg>
           </span>
         </summary>
-        <p class="t-serif has-b-btm-marg">A sustaining membership means your donation recurs automatically on a monthly or yearly basis via credit card. Members with recurring gifts help the Tribune pursue big stories and projects and plan budgets a few years at a time. Sustaining memberships also help eliminate lapses in your membership.</p>
+        <p class="t-serif has-b-btm-marg">A sustaining membership means your donation recurs automatically on a monthly or yearly basis via credit card. Members with recurring gifts help the Tribune pursue big stories and budget for the future. Sustaining memberships also help eliminate lapses in your membership.</p>
         <p class="t-serif has-b-btm-marg">
-          You can update the credit card information associated with your monthly or yearly donation on your Tribune account.
+          You can easily cancel or update the credit card information associated with your monthly or yearly donation on your Tribune account.
           <a href="https://texastribune.org/login">Log in</a>, then update your payment information from the “Membership” tab.
         </p>
         <p class="t-serif has-b-btm-marg">
@@ -62,7 +63,7 @@
         <p class="t-serif has-b-btm-marg">
           We understand circumstances change. You may cancel a recurring gift at any time by
           <a href="https://texastribune.org/signup">signing up</a> or
-          <a href="https://texastribune.org/login">logging into</a> your Texas Tribune account. Any donation you’ve made in the last 365 days still counts toward your annual membership.
+          <a href="https://texastribune.org/login">logging into</a> your Texas Tribune account.
         </p>
       </details>
     </li>
@@ -76,12 +77,7 @@
             </svg>
           </span>
         </summary>
-        <p class="t-serif has-b-btm-marg">If you’re looking to renew your membership, make a donation to the Tribune. Your membership renews for one full year after you make a donation.</p>
-        <p class="t-serif has-b-btm-marg">
-          Sustaining memberships automatically renew on a monthly or yearly basis. If you need to update your credit card information,
-          <a href="http://texastribune.org/login">log in</a> to your Tribune account. If you need assistance, please contact
-          <a href="mailto:membership@texastribune.org">membership@texastribune.org</a>.
-        </p>
+        <p class="t-serif has-b-btm-marg">Make a new donation to the Tribune to renew your membership. A donation makes you a Texas Tribune member for one year.</p>
       </details>
     </li>
     <li class="c-faq__item">
@@ -109,6 +105,22 @@
               Austin, Texas 78701<br />
             </em>
           </span>
+        </p>
+      </details>
+    </li>
+    <li class="c-faq__item">
+      <details>
+        <summary class="c-faq__summary l-pos-rel gtm-custom-ga-dropdown" data-qa-title="FAQ" data-qa-question="Do Texas Tribune members get any perks?">
+          <h3 class="t-size-s">Do Texas Tribune members get any perks?</h3>
+          <span class="c-icon c-icon--baseline t-size-xs c-faq__icon c-icon l-height-full l-pos-abs">
+            <svg aria-hidden="true">
+              <use href="#caret-down"></use>
+            </svg>
+          </span>
+        </summary>
+        <p class="t-serif has-b-btm-marg">
+          Texas Tribune members receive a monthly newsletter with a look inside the Tribune newsroom, plus
+          <a href="https://www.texastribune.org/member-benefits/">other benefits throughout the year</a>.
         </p>
       </details>
     </li>
@@ -167,7 +179,7 @@
           </span>
         </summary>
         <p class="t-serif has-b-btm-marg">
-          For questions about membership:.<br />
+          For questions about membership:<br />
           Leave us a message at 512-993-0166<br />
           Email us at
           <a href="mailto:membership@texastribune.org">membership@texastribune.org</a>


### PR DESCRIPTION
#### What's this PR do?
Removes the benefits section and adds a new entry in the FAQ module that points to a benefits flat page. Also makes some minor copy edits requested by membership.

#### Why are we doing this? How does it help us?
We're trying to clean up the donation form page so that it's less busy in hopes of driving more donation follow-through.

#### How should this be manually tested?
Make
Visit local.texastribune.org/donate
Ensure the page only shows the donation form and the FAQ module (side by side)
Check out the 3rd to last entry in the FAQ module and click the link there
Ensure the link works and the linked page shows benefit information

#### How should this change be communicated to end users?
I'll let membership know their update requests are live.

#### Are there any smells or added technical debt to note?
Only thing to mention is that the Waco Bridge donate page will still show the benefits for now, but we can discuss that with membership later.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/receTXRmnGtEJwGCc?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
