### PR TITLE
adding in donor wall query pieces from tt app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ slack-sdk==3.12.0
 pydantic==1.9.0
 pytest-mock==3.10.0
 pytest-recording==0.12.2
+boto3==1.19.7

--- a/server/app.py
+++ b/server/app.py
@@ -67,6 +67,7 @@ from .util import (
     send_slack_message,
     send_cancellation_notification,
     name_splitter,
+    _push_to_s3,
 )
 
 ZONE = timezone(TIMEZONE)
@@ -1171,6 +1172,12 @@ def authorization_notification(payload):
     notify_slack(contact=contact, opportunity=opportunity)
     if contact.duplicate_found:
         send_multiple_account_warning(contact)
+
+
+@celery.task(name="app.push_donor_list")
+def push_donor_list():
+    donor_list = Account.list_by_giving()
+    _push_to_s3(filename='donors-waco-365.json', contents=donor_list)
 
 
 def get_zip(details=None):

--- a/server/config.py
+++ b/server/config.py
@@ -134,6 +134,8 @@ MWS_SECRET_KEY = os.getenv("MWS_SECRET_KEY", "")
 AMAZON_MERCHANT_ID = os.getenv("AMAZON_MERCHANT_ID", "")
 AMAZON_SANDBOX = bool_env("AMAZON_SANDBOX")
 AMAZON_CAMPAIGN_ID = os.getenv("AMAZON_CAMPAIGN_ID", "")
+AMAZON_S3_BUCKET = os.getenv("AMAZON_S3_BUCKET", "membership.texastribune.org")
+
 #######
 # Tasks
 #

--- a/server/util.py
+++ b/server/util.py
@@ -1,5 +1,6 @@
-import json
+import boto3
 import hashlib
+import json
 import logging
 import smtplib
 import stripe
@@ -8,6 +9,9 @@ from collections import defaultdict
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 from .config import (
+    MWS_ACCESS_KEY,
+    MWS_SECRET_KEY,
+    AMAZON_S3_BUCKET,
     BUSINESS_MEMBER_RECIPIENT,
     DEFAULT_MAIL_SENDER,
     ENABLE_SLACK,
@@ -365,3 +369,15 @@ def donation_adder(customer: str, donation_type: str, amount: int, pay_fees: boo
         }]
     )
     return subscription
+
+
+def _push_to_s3(filename, contents):
+    # Create an S3 client, gives you lowest level access to S3 control
+    s3_client = boto3.client('s3',
+                             aws_access_key_id=MWS_ACCESS_KEY,
+                             aws_secret_access_key=MWS_SECRET_KEY,)
+
+    # Wtite the JSON-formatted SF data to the S3 bucket
+    s3_client.put_object(ACL='public-read',
+                         Body=json.dumps(contents, indent=2),
+                         Bucket=AMAZON_S3_BUCKET, Key=filename)


### PR DESCRIPTION
#### What's this PR do?
Moves over initial pieces from the donor wall in the TT app
* adding boto3 to requirements for library to push data to s3
* moving query functionality to Account class in npsp
* moving _push_to_s3 function to util
* adding celery task that can be triggered nightly to push to s3

#### Why are we doing this? How does it help us?
We need to move the donor wall out of the TT app and this gets the process to a point where it should be able to export a json file of donor info to s3 for further perusal.

#### How should this be manually tested?
I'll deploy this to donations-staging and should be able to start a nightly batch job from there.

#### How should this change be communicated to end users?
Doesn't need to be right now.

#### Are there any smells or added technical debt to note?
This currently grabs all donors for any TT newsroom (Texas or Waco). I'm currently working with our salesforce contractor to utilize newsroom-specific giving fields for this going forward.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recNQphHKCt7YNFKJ?blocks=hide
