### PR TITLE
Add route for donor wall, pull in static header content

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -882,6 +882,11 @@ def daf():
         bundles=bundles,
     )
 
+@app.route("/donor-wall")
+def donor_wall():
+    bundles = get_bundles("donate")
+    return render_template("donor-wall.html", bundles=bundles)
+
 @app.route("/error")
 def error():
     bundles = get_bundles(NEWSROOM["name"] if NEWSROOM["name"] != "texas" else "old")

--- a/server/templates/donor-wall.html
+++ b/server/templates/donor-wall.html
@@ -1,0 +1,42 @@
+{% extends "new_layout.html" %}
+
+{% block og_meta %}
+  <meta property="og:url" content="https://support.texastribune.org/donate">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
+  <meta property="og:title" content="Support Us | The Texas Tribune">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
+  <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
+{% block head_scripts %}
+{% if form_data and message %}
+<script>
+  window.location.replace('#join-today');
+</script>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+  <main id="main-tt-content" class="l-container">
+    <header class="has-page-padding">
+      <h1 class="t-serif has-b-btm-marg">Our Supporters</h1>
+      <div class="has-notch has-bg-yellow has-xxl-btm-marg"></div>
+    </header>
+    <div class="t-serif t-links-underlined t-size-b has-page-padding">
+
+      <p class="has-b-btm-marg">Donors and members subscribe to The Texas Tribune’s belief that promoting greater civic engagement and informed discourse is a direct route to a better and more productive Texas. They play no role in guiding the journalism produced by the Tribune or the planning and execution of events.</p>
+      <p class="has-b-btm-marg">If you are interested in becoming a donor or a member, click <a href="https://support.texastribune.org/donate">here</a>.</p>
+      <p class="has-b-btm-marg">When it comes to our donors and <a href="/support-us/corporate-sponsors/">corporate sponsors</a>, the Tribune is committed to full transparency. Current-year and all time totals below include both pledged and received gifts. Amounts listed are updated daily and are subject to change. If you have a question about an amount you see below, please contact us at <a href="mailto:membership@texastribune.org">membership@texastribune.org</a>.</p>
+      <p class="has-b-btm-marg">When donors or <a href="/support-us/corporate-sponsors/">corporate sponsors</a> who have given $1,000 or more to the Tribune are named in our stories, we disclose them on those pages.</p>
+      <p class="has-b-btm-marg">The Texas Tribune also earns income from <a href="https://festival.texastribune.org/">Texas Tribune Festival</a> ticket sales; outside rentals of <a href="/studio-919/downtown-austin-event-space-congress/">Studio 919</a>, our events space; and subscriptions to <a href="/theblast/">The Blast</a>, our politics newsletter. That revenue is not reported here but can be found in aggregate on our <a href="http://static.texastribune.org.s3.amazonaws.com/media/documents/990_TexasTribune_Final_111417.pdf">Form 990</a>.</p>
+
+    </div>
+  </main>
+{% endblock %}
+
+{% block bottom_script %}
+
+{% endblock %}
+
+


### PR DESCRIPTION
#### What's this PR do?

Adds a route for `/donor-wall`, which is the start of the port of the donor wall app from `texas-tribune` to the `donations` app.

Merging into `feature/donor-wall` as a long-running feature branch.

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

After running locally, go to [http://localhost/donor-wall](http://localhost/donor-wall). You should get a 200 response with some stub content.

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
