### PR TITLE
removing blast legislative option

### DIFF
--- a/server/static/js/src/connected-elements/FormBuckets.vue
+++ b/server/static/js/src/connected-elements/FormBuckets.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grid_row grid_wrap--m form-buckets">
+  <div class="grid_row_centered grid_wrap--m form-buckets">
     <div
       v-for="bucket in buckets"
       :key="bucket.id"

--- a/server/static/js/src/entry/blast/constants.js
+++ b/server/static/js/src/entry/blast/constants.js
@@ -35,15 +35,15 @@ export const BLAST_LEVELS = {
   //   installmentPeriod: 'yearly',
   //   amount: '199',
   // },
-  blastLegislativeSession: {
-    bucket: 'legislative',
-    bucketFull: 'Legislative session-only',
-    installmentPeriod: 'one-time',
-    amount: '200',
-    isFeatured: true,
-    prompt: 'Get ahead with insider news!',
-    footer: 'January 14 – June 14',
-  },
+  // blastLegislativeSession: {
+  //   bucket: 'legislative',
+  //   bucketFull: 'Legislative session-only',
+  //   installmentPeriod: 'one-time',
+  //   amount: '200',
+  //   isFeatured: true,
+  //   prompt: 'Get ahead with insider news!',
+  //   footer: 'January 14 – June 14',
+  // },
 };
 
 export const BLAST_FORM_STATE = {

--- a/server/static/sass/7-utilities/_grid.scss
+++ b/server/static/sass/7-utilities/_grid.scss
@@ -73,6 +73,12 @@
     flex-wrap: nowrap;
   }
 
+  &_row_centered {
+    @extend %flex-grid;
+    flex-wrap: nowrap;
+    justify-content: center;
+  }
+
   // .grid_padded -- DEFAULT
   // adds left/right padding on small screens
   &_padded {


### PR DESCRIPTION
#### What's this PR do?
* adds grid_row_centered css class
* removes legislative option from blast sign-up form
* uses grid_row_centered to center remaining two blast sign-up options

#### Why are we doing this? How does it help us?
The legislative option no longer applies so we need to lose it.

#### How should this be manually tested?
Doesn't need to be.

#### How should this change be communicated to end users?
I'll update the blast channel Monday morning.

#### Are there any smells or added technical debt to note?
The new grid_row_centered css class affects any form buckets, but I went through the /business and /circle pages and saw no unintended side-effects.

#### What are the relevant tickets?
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recM3YxaENdyiFxPO?blocks=hide

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
