### PR TITLE
setup scheduled export of donor list

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -15,6 +15,7 @@ from pprint import pformat
 import stripe
 from amazon_pay.client import AmazonPayClient
 from amazon_pay.ipn_handler import IpnHandler
+from celery import shared_task
 from flask import Flask, redirect, render_template, request, send_from_directory, url_for
 from flask_talisman import Talisman
 from nameparser import HumanName
@@ -1179,7 +1180,7 @@ def authorization_notification(payload):
         send_multiple_account_warning(contact)
 
 
-@celery.task(name="app.push_donor_list")
+@shared_task()
 def push_donor_list():
     donor_list = Account.list_by_giving()
     _push_to_s3(filename='donors-waco-365.json', contents=donor_list)

--- a/server/config.py
+++ b/server/config.py
@@ -38,7 +38,7 @@ CELERY_ALWAYS_EAGER = bool_env("CELERY_ALWAYS_EAGER")
 # deprecated:
 CELERYBEAT_SCHEDULE = {
     "every-day": {
-        "task": "server.batch.charge_cards",
+        "task": "server.app.push_donor_list",
         "schedule": crontab(minute="0", hour=BATCH_HOURS),
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Sets up the push_donor_list function to run on a schedule determined by an env var (BATCH_HOURS)

#### Why are we doing this? How does it help us?
This creates an updated json file of donors for the last 365 days that we can ref instead of having to do a direct (and costly) salesforce call on the donor wall page.

#### How should this be manually tested?
I'll deploy this branch to staging when appropriate and test out the celery scheduling functionality (kind of hard to test that part locally).

#### How should this change be communicated to end users?
Doesn't need to be.

#### Are there any smells or added technical debt to note?
None come to mind.

#### What are the relevant tickets?

