### PR TITLE
Feat/remove smd 26

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -79,7 +79,7 @@ from .util import (
 )
 
 ZONE = timezone(TIMEZONE)
-USE_THERMOMETER = True
+USE_THERMOMETER = False
 
 DONATION_TYPE_INFO = {
     "membership": {

--- a/server/static/js/src/entry/donate/Thermometer.vue
+++ b/server/static/js/src/entry/donate/Thermometer.vue
@@ -8,8 +8,8 @@
       ></div>
     </div>
     <div class="text">
-      <strong>{{ data[0].label }} raised today</strong> <br />
-      to unlock {{ data[1].label }} in matching funds.
+      <strong>{{ data[0].label }} new members</strong> <br />
+      toward goal of {{ data[1].label }}.
     </div>
   </div>
 </template>
@@ -26,7 +26,7 @@ export default {
       error: false,
       data: [
         { slug: 'actual', label: '0', value: 0 },
-        { slug: 'goal', label: '$15,000', value: 15000 },
+        { slug: 'goal', label: '500', value: 500 },
       ],
     };
   },
@@ -43,7 +43,7 @@ export default {
 
   methods: {
     getSalesforceReport() {
-      const url = 'https://membership.texastribune.org/gt2024.json';
+      const url = 'https://membership.texastribune.org/smd2026.json';
 
       axios
         .get(url)

--- a/server/static/js/src/entry/donate/Thermometer.vue
+++ b/server/static/js/src/entry/donate/Thermometer.vue
@@ -8,8 +8,8 @@
       ></div>
     </div>
     <div class="text">
-      <strong>{{ data[0].label }} new members</strong> <br />
-      toward goal of {{ data[1].label }}.
+      <strong>{{ data[0].label }} raised today</strong> <br />
+      to unlock {{ data[1].label }} in matching funds.
     </div>
   </div>
 </template>
@@ -26,7 +26,7 @@ export default {
       error: false,
       data: [
         { slug: 'actual', label: '0', value: 0 },
-        { slug: 'goal', label: '500', value: 500 },
+        { slug: 'goal', label: '$15,000', value: 15000 },
       ],
     };
   },
@@ -43,7 +43,7 @@ export default {
 
   methods: {
     getSalesforceReport() {
-      const url = 'https://membership.texastribune.org/smd2026.json';
+      const url = 'https://membership.texastribune.org/gt2024.json';
 
       axios
         .get(url)

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-smd26.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
@@ -36,7 +36,7 @@
     {% endif %}
 
     <section class="grid_container grid_padded--xl grid_separator--xl">
-      <div class="grid_row grid_wrap--l gap-s l-align-center-children">
+      <div class="grid_row grid_wrap--l gap-s">
         <div class="col_7">
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
@@ -69,7 +69,7 @@
 
     <section class="section-padding grid_padded--xl section-padding--filled">
       {% if use_thermometer %}
-        <div class="grid_container grid_row grid_wrap--l gap-s l-swap--from-bp-m l-align-center-children">
+        <div class="grid_container grid_row grid_wrap--l gap-s l-swap--from-bp-m">
           <div class="col_5">
             {% include 'includes/faq.html' %}
           </div>

--- a/server/templates/donate-form.html
+++ b/server/templates/donate-form.html
@@ -2,7 +2,7 @@
 
 {% block og_meta %}
   <meta property="og:url" content="https://support.texastribune.org/donate">
-  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social.png') }}">
+  <meta property="og:image" content="https://support.texastribune.org{{ url_for('static', filename='img/social-smd26.png') }}">
   <meta property="og:title" content="Support Us | The Texas Tribune">
   <meta property="og:type" content="website">
   <meta property="og:description" content="Members make our journalism possible. Support The Texas Tribune with a donation today.">
@@ -36,7 +36,7 @@
     {% endif %}
 
     <section class="grid_container grid_padded--xl grid_separator--xl">
-      <div class="grid_row grid_wrap--l gap-s">
+      <div class="grid_row grid_wrap--l gap-s l-align-center-children">
         <div class="col_7">
           <div id="join-today" class="donation_form grid_separator--l">
             <!-- where the router component attaches -->
@@ -69,7 +69,7 @@
 
     <section class="section-padding grid_padded--xl section-padding--filled">
       {% if use_thermometer %}
-        <div class="grid_container grid_row grid_wrap--l gap-s l-swap--from-bp-m">
+        <div class="grid_container grid_row grid_wrap--l gap-s l-swap--from-bp-m l-align-center-children">
           <div class="col_5">
             {% include 'includes/faq.html' %}
           </div>


### PR DESCRIPTION
#### What's this PR do?
reverts donations back to pre-smd 26, while still keeping the checkbox defaulted to checked

#### Why are we doing this? How does it help us?
SMD '26 is ova

#### How should this be manually tested?

#### How should this change be communicated to end users?
I'll let Emily know

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *( )*

#### TODOs / next steps:

* [ ] *your TODO here*
