### PR TITLE
Add/ac business memb links

### DIFF
--- a/docker-compose.shell.yml
+++ b/docker-compose.shell.yml
@@ -12,4 +12,4 @@ services:
       - /bin/sh
       - ./shell.sh
     env_file:
-      - ./env-docker
+      - ./env-docker.shell

--- a/server/static/sass/austin.scss
+++ b/server/static/sass/austin.scss
@@ -177,7 +177,7 @@ body {
     }
 
     @media only screen and (min-width: 600px) {
-      font-size: 30px;
+      font-size: 20px;
       line-height: 48px;
     }
   }

--- a/server/templates/includes/footer_austin.html
+++ b/server/templates/includes/footer_austin.html
@@ -34,7 +34,10 @@
       <div class="c-footer-newsroom__list-top-border"></div>
       <ul class="has-b-btm-marg has-b-top-marg c-footer-newsroom__list-top t-font-secondary t-weight-normal">
         <li>
-          <a href="https://support.{{ newsroom.domain }}/" class="has-text-white">Support</a>
+          <a href="https://support.{{ newsroom.domain }}/" class="has-text-white">Support Us</a>
+        </li>
+        <li>
+          <a href="https://support.{{ newsroom.domain }}/business/" class="has-text-white">Business Membership</a>
         </li>
         <li>
           <a href="https://{{ newsroom.domain }}/about/" class="has-text-white">About</a>

--- a/server/templates/includes/navbar_austin.html
+++ b/server/templates/includes/navbar_austin.html
@@ -40,6 +40,9 @@
       <li>
         <a href="https://support.{{ newsroom.domain }}">Support Us</a>
       </li>
+      <li>
+        <a href="https://support.{{ newsroom.domain }}/business">Business Membership</a>
+      </li>
     </ul>
     <div class="c-menu__logo">
       <img src="{{ url_for('static', filename='/img/austin-stacked-white.svg') }}" width="120" height="106" alt="{{ newsroom.title }} logo" />


### PR DESCRIPTION
#### What's this PR do?
Adds business membership links to AC support pages in the left-hand nav and the footer

#### Why are we doing this? How does it help us?
Bring easier access to the business memb. page

#### How should this be manually tested?
Check for the links in the nav and the footer

#### How should this change be communicated to end users?

